### PR TITLE
android - fix NullPointerExceptions when disabling push notifications

### DIFF
--- a/android/src/com/pubnub/api/Pubnub.java
+++ b/android/src/com/pubnub/api/Pubnub.java
@@ -192,11 +192,11 @@ public class Pubnub extends PubnubCoreShared {
                             PubnubError.getErrorObject(PubnubError.PNERROBJ_INVALID_JSON, 1, response));
                     return;
                 }
-                callback.successCallback("", jsarr);
+                cb.successCallback("", jsarr);
             }
 
             public void handleError(HttpRequest hreq, PubnubError error) {
-                callback.errorCallback("", error);
+                cb.errorCallback("", error);
                 return;
             }
         });
@@ -274,11 +274,11 @@ public class Pubnub extends PubnubCoreShared {
                             PubnubError.getErrorObject(PubnubError.PNERROBJ_INVALID_JSON, 1, response));
                     return;
                 }
-                callback.successCallback("", jsarr);
+                cb.successCallback("", jsarr);
             }
 
             public void handleError(HttpRequest hreq, PubnubError error) {
-                callback.errorCallback("", error);
+                cb.errorCallback("", error);
                 return;
             }
         });
@@ -316,11 +316,11 @@ public class Pubnub extends PubnubCoreShared {
                             PubnubError.getErrorObject(PubnubError.PNERROBJ_INVALID_JSON, 1, response));
                     return;
                 }
-                callback.successCallback("", jsarr);
+                cb.successCallback("", jsarr);
             }
 
             public void handleError(HttpRequest hreq, PubnubError error) {
-                callback.errorCallback("", error);
+                cb.errorCallback("", error);
                 return;
             }
         });
@@ -364,11 +364,11 @@ public class Pubnub extends PubnubCoreShared {
                             PubnubError.getErrorObject(PubnubError.PNERROBJ_INVALID_JSON, 1, response));
                     return;
                 }
-                callback.successCallback("", jsarr);
+                cb.successCallback("", jsarr);
             }
 
             public void handleError(HttpRequest hreq, PubnubError error) {
-                callback.errorCallback("", error);
+                cb.errorCallback("", error);
                 return;
             }
         });


### PR DESCRIPTION
When calling the wrapper functions that do no have a callback parameter, e.g. ```public void disablePushNotificationsOnChannel(String channel, String gcmRegistrationId)```, the wrapped functions get called with ```null``` as the callback parameter.

This leads to a ```NullPointerException``` as the ```successCallback``` and ```errorCallback``` functions get called on the ```callback``` object (that is ```null```) and not the ```cb``` object (not-```null``` object returned by ```getWrappedCallback(callback)```)