### PR TITLE
Fix for callback not being added in the arguments  in PubnubCore.publish()

### DIFF
--- a/java/srcPubnubApi/com/pubnub/api/PubnubCore.java
+++ b/java/srcPubnubApi/com/pubnub/api/PubnubCore.java
@@ -631,6 +631,7 @@ abstract class PubnubCore {
         Hashtable args = new Hashtable();
         args.put("channel", channel);
         args.put("message", message);
+        args.put("callback", callback);
         args.put("storeInHistory", (storeInHistory)?"":"0");
         publish(args);
     }


### PR DESCRIPTION
In the method (the one that takes JSONObject) `PubnubCore.publish()`, somebody forgot to put an instance of `Callback` into the arguments map.
Spend a couple of hours to figure out what's wrong and why my callback wasn't being called... until looked into the code. :)
