### PR TITLE
Check for null before calling a method on Callback

### DIFF
--- a/android/src/com/pubnub/api/Pubnub.java
+++ b/android/src/com/pubnub/api/Pubnub.java
@@ -372,11 +372,15 @@ public class Pubnub extends PubnubCoreShared {
                             PubnubError.getErrorObject(PubnubError.PNERROBJ_INVALID_JSON, 1, response));
                     return;
                 }
-                callback.successCallback("", jsarr);
+                if (callback != null) {
+                    callback.successCallback("", jsarr);
+                }
             }
 
             public void handleError(HttpRequest hreq, PubnubError error) {
-                callback.errorCallback("", error);
+                if (callback != null) {
+                    callback.errorCallback("", error);
+                }
                 return;
             }
         });

--- a/android/src/com/pubnub/api/Pubnub.java
+++ b/android/src/com/pubnub/api/Pubnub.java
@@ -192,11 +192,15 @@ public class Pubnub extends PubnubCoreShared {
                             PubnubError.getErrorObject(PubnubError.PNERROBJ_INVALID_JSON, 1, response));
                     return;
                 }
-                callback.successCallback("", jsarr);
+                if (callback != null) {
+                    callback.successCallback("", jsarr);
+                }
             }
 
             public void handleError(HttpRequest hreq, PubnubError error) {
-                callback.errorCallback("", error);
+                if (callback != null) {
+                    callback.errorCallback("", error);
+                }
                 return;
             }
         });
@@ -274,11 +278,15 @@ public class Pubnub extends PubnubCoreShared {
                             PubnubError.getErrorObject(PubnubError.PNERROBJ_INVALID_JSON, 1, response));
                     return;
                 }
-                callback.successCallback("", jsarr);
+                if (callback != null) {
+                    callback.successCallback("", jsarr);
+                }
             }
 
             public void handleError(HttpRequest hreq, PubnubError error) {
-                callback.errorCallback("", error);
+                if (callback != null) {
+                    callback.errorCallback("", error);
+                }
                 return;
             }
         });


### PR DESCRIPTION
disablePushNotificationsOnChannels(String[], String) calls disablePushNotificationsOnChannels(final String[], String, final Callback) with `null` for the Callback.  Check for null before calling a method on it.