### PR TITLE
Added Andorid XML constructor so different activities can refer to on…

### DIFF
--- a/android/src/com/pubnub/api/Pubnub.java
+++ b/android/src/com/pubnub/api/Pubnub.java
@@ -2,9 +2,18 @@ package com.pubnub.api;
 
 import java.util.Hashtable;
 import java.util.UUID;
+import java.io.IOException;
 
 import org.json.JSONArray;
 import org.json.JSONException;
+
+import android.content.Context;
+import android.content.res.XmlResourceParser;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+
 
 /**
  * Pubnub object facilitates querying channels for messages and listening on
@@ -115,6 +124,60 @@ public class Pubnub extends PubnubCoreShared {
     public Pubnub(String publish_key, String subscribe_key,
                   String secret_key, String cipher_key, boolean ssl_on, String initialization_vector) {
         super(publish_key, subscribe_key, secret_key, cipher_key, ssl_on, initialization_vector);
+    }
+
+    /**
+     *
+     * Constructor for Pubnub Class from XML
+     *
+     * @param context
+     *            Android Activity context
+     * @param xmlResourceId
+     *            The resource ID of an XML file describing PubNub configurations (e.g. R.xml.pn_config)
+     */
+
+    public Pubnub(Context context, int xmlResourceId) {
+        String publish_key=null;
+        String subscribe_key=null;
+        String secret_key="";
+        String cipher_key="";
+        boolean ssl_on=false;
+
+        String currentTag=null;
+        try {
+            XmlResourceParser xpp = context.getResources().getXml(xmlResourceId);
+            int eventType = xpp.getEventType();
+            while (eventType != XmlPullParser.END_DOCUMENT) {
+                if (eventType == XmlPullParser.START_TAG) {
+                    if (xpp.getName().equals("resources")){
+                        eventType = xpp.next();
+                        continue;
+                    }
+                    currentTag = xpp.getAttributeValue(null, "name");
+                } else if (eventType == XmlPullParser.TEXT) {
+                    if (currentTag == null){ // Ignore improper formatting
+                        eventType = xpp.next();
+                        continue;
+                    }
+                    if (currentTag.equals("pn_pubKey")){
+                        publish_key = xpp.getText();
+                    } else if (currentTag.equals("pn_subKey")) {
+                        subscribe_key = xpp.getText();
+                    } else if (currentTag.equals("pn_secretKey")) {
+                        secret_key = xpp.getText();
+                    } else if (currentTag.equals("pn_cipherKey")) {
+                        cipher_key = xpp.getText();
+                    } else if (currentTag.equals("pn_sslOn")){
+                        ssl_on = Boolean.parseBoolean(xpp.getText());
+                    }
+                }
+                eventType = xpp.next();
+            }
+        }
+        catch (XmlPullParserException e){ e.printStackTrace(); }
+        catch (IOException e){ e.printStackTrace(); }
+
+        super(publish_key, subscribe_key, secret_key, cipher_key, ssl_on);
     }
 
     protected String getUserAgent() {


### PR DESCRIPTION
…e standard xml resource.

Many larger android libraries that require configurations allow for an XML file [such as Google's Mobile Analytics](https://developers.google.com/analytics/devguides/collection/android/v4/#analytics-xml) to define those parameters. I wrote some code a short time ago that allowed me to do this so I figured I would add this feature to the PubNub Android SDK.

__This pull request is not release ready.__

I am not sure how your configurations and dependencies work in such a large repo with multiple libraries so this will likely require a little tweaking of pom files. Also, I only modifies the android `Pubnub.java` file, I left all version codes as they were for now. 

The following imports were used. They are all part of the native Android SDK, so no additional gradle dependencies are required if building in Android Studio.

```
import android.content.Context;
import android.content.res.XmlResourceParser;

import org.xmlpull.v1.XmlPullParser;
import org.xmlpull.v1.XmlPullParserException;

import java.io.IOException;
```

This added constructor allows for a user to define a resourse, e.g. `res/xml/pn_config.xml`, which would look as follows:

```
<?xml version="1.0" encoding="utf-8" ?>
<resources>
    <string name="pn_pubKey">my_pub_key</string>
    <string name="pn_subKey">my_sub_key</string>
    <string name="pn_secretKey">my_secret_key</string>
    <string name="pn_cipherKey">my_cipher_key</string>
    <bool name="pn_sslOn">false</bool>
</resources>
```

_Note: All fields may be omitted other than `pn_pubKey` and `pn_subKey`_

This will allow a PubNub object to be created in different activities using the following code:

    Pubnub pubnub = new Pubnub(this, R.xml.pn_config);

This is useful for Apps with multiple activities, makes it easier to instantiate Pubnub as a separate instance variable in activities that require it.

Again, this is based on a function I wrote for a separate project. The function looks identical, just has a different non-constructor name, and works like a charm, but since I do not understand how to use the github repo in my Android Project I was unable to formally test this. If incorporating this causes too much trouble feel free to ignore it.