### PR TITLE
Possibility to change origin URL for cases like testing

### DIFF
--- a/java/srcPubnubApi/com/pubnub/api/PubnubCore.java
+++ b/java/srcPubnubApi/com/pubnub/api/PubnubCore.java
@@ -25,6 +25,7 @@ abstract class PubnubCore {
     private int HOSTNAME_SUFFIX = 1;
     private String DOMAIN = "pubnub.com";
     private String ORIGIN_STR = null;
+    private String OVERRIDED_ORIGIN = null;
     protected String PUBLISH_KEY = "";
     protected String SUBSCRIBE_KEY = "";
     protected String SECRET_KEY = "";
@@ -2664,7 +2665,7 @@ abstract class PubnubCore {
     }
 
     private void changeOrigin() {
-        this.ORIGIN_STR = null;
+        this.ORIGIN_STR = this.OVERRIDED_ORIGIN;
         this.HOSTNAME_SUFFIX = getRandom();
     }
 
@@ -2807,6 +2808,11 @@ abstract class PubnubCore {
         this.AUTH_STR = null;
         params.remove("auth");
         resubscribe();
+    }
+
+    public void overrideOrigin(String origin) {
+        this.OVERRIDED_ORIGIN = origin;
+        this.ORIGIN_STR = this.OVERRIDED_ORIGIN;
     }
 
 }


### PR DESCRIPTION
This patch adds possibility to override harcoded domain "pubnub.com" to any custom domain. It is very useful in testing scenarios.

As modern developer I like to perform load and stress testing for my awesome product(http://www.ringcentral.com). In same time, I do not want to my company be charged for fake messages, so I need to configure library to connect to host like "mycomany.com/pubnub-emulator" instead of "pubnub.com". Previously, to solve this problem, I maintained own fork for official Pubnub library, but it is to boring to release own custom library each time when official library is released. So please integrate this pull request to your codebase. 