### PR TITLE
Set new threads as daemon threads to allow application shutdown

### DIFF
--- a/java/srcPubnubApi/com/pubnub/api/RequestManager.java
+++ b/java/srcPubnubApi/com/pubnub/api/RequestManager.java
@@ -155,7 +155,9 @@ abstract class RequestManager {
         synchronized (_workers) {
             for (int i = 0; i < maxCalls; ++i) {
                 Worker w = getWorker();
-                w.setThread(new Thread(w, name + "-" + ++count));
+                Thread thread = new Thread(w, name + "-" + ++count);
+                thread.setDaemon(true);
+                w.setThread(thread);
                 _workers[i] = w;
                 log.verbose("Starting new worker " + _workers[i].getThread().getName());
                 w.startWorker();
@@ -197,7 +199,9 @@ abstract class RequestManager {
                 new Thread(new ConnectionResetter(_workers[i])).start();
                 _workers[i].interruptWorker();
                 Worker w = getWorker();
-                w.setThread(new Thread(w, name + "-" + ++count));
+                Thread thread = new Thread(w, name + "-" + ++count);
+                thread.setDaemon(true);
+                w.setThread(thread);
                 _workers[i] = w;
                 log.verbose("Starting new worker " + _workers[i].getThread().getName());
                 w.startWorker();

--- a/java/srcPubnubApi/com/pubnub/api/TimedTaskManager.java
+++ b/java/srcPubnubApi/com/pubnub/api/TimedTaskManager.java
@@ -104,7 +104,9 @@ public class TimedTaskManager {
 
     public int addTask(String name, TimedTask task) {
         TimedTaskWorker w = new TimedTaskWorker(name, task);
-        w.setThread(new Thread(w, name + "-" + ++count));
+        Thread thread = new Thread(w, name + "-" + ++count);
+        thread.setDaemon(true);
+        w.setThread(thread);
         _workers.add(w);
         log.verbose("Starting new worker " + w.getThread().getName());
         w.startWorker();


### PR DESCRIPTION
Hi,

When our application starts up, if it detects invalid configuration then it fails fast.  Adding pubnub to our application then prevents this behaviour.

Pubnub creates two worker threads from the main thread.  Since these are user threads (by default), when the main thread then terminates the application doesn't shut down, leaving the application in a non functioning state.  Please see http://docs.oracle.com/javase/6/docs/api/java/lang/Thread.html for more information on daemon vs user threads.

This request then changes the threads immediately after creation to be daemon threads so that when the main thread terminates the application then terminates too.   