### PR TITLE
Fix internalization bug in message deserialization for case when JVM file.encoding is not UTF-8

### DIFF
--- a/java/src1/com/pubnub/api/HttpClientCore.java
+++ b/java/src1/com/pubnub/api/HttpClientCore.java
@@ -76,7 +76,7 @@ class HttpClientCore extends HttpClient {
             n = in.read(bytes);
         }
 
-        return new String(out.toString());
+        return new String(out.toString("utf8"));
     }
 
     public HttpResponse fetch(String url) throws PubnubException, SocketTimeoutException {

--- a/java/srcTest/com/pubnub/api/PubnubTest.java
+++ b/java/srcTest/com/pubnub/api/PubnubTest.java
@@ -231,6 +231,32 @@ public class PubnubTest {
         assertEquals(sendMessage, sbCb.getResponse());
     }
 
+    /**
+     * It is need to run JVM with option -Dfile.encoding=windows-1251(or something else latin incompatible encoding) in order to reproduce issue which covered by this test
+     */
+    @Test
+    public void testPublishNonLatinString() throws PubnubException, InterruptedException {
+        String channel = "java-unittest-" + Math.random();
+        final String sendMessage = "\u0440\u0443\u0441\u0441\u043a\u0438\u0439 " + Math.random();
+
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        final PublishCallback pbCb = new PublishCallback(latch);
+        SubscribeCallback sbCb = new SubscribeCallback(latch) {
+            @Override
+            public void connectCallback(String channel, Object message) {
+                pubnub.publish(channel, sendMessage, pbCb);
+            }
+        };
+
+        pubnub.subscribe(channel, sbCb);
+
+        latch.await(10, TimeUnit.SECONDS);
+
+        assertEquals(1, pbCb.getResult());
+        assertEquals(sendMessage, sbCb.getResponse());
+    }
+
     @Test
     public void testPublishJSONArray() throws PubnubException, InterruptedException {
         String channel = "java-unittest-" + Math.random();


### PR DESCRIPTION
There is the bug in the com.pubnub.api.HttpClientCore
```java
...
private static String readInput(InputStream in) throws IOException {
        ByteArrayOutputStream out = new ByteArrayOutputStream();
        byte bytes[] = new byte[1024];

        int n = in.read(bytes);

        while (n != -1) {
            out.write(bytes, 0, n);
            n = in.read(bytes);
        }

        return new String(out.toString());
    }
...
```
Due to [ByteArrayOutputStream.html#toString](http://docs.oracle.com/javase/7/docs/api/java/io/ByteArrayOutputStream.html#toString())  uses platform's default character set. As result message which contains non-latin characters(for example russian text) can not be properly deserialized in case of JVM started with file encoding which differs from  UTF-8 or ISO-8859-1.  Fail happens because Pubnub service always returns HTTP responses encoded in UTF-8, but in same time client library tries to read response via system encoding which may differ from UTF-8.

I have attached a good unit test for this request which reproduces the problem, test fails before fix in HttpClientCore and passes after fix. Just run it with JVM option -Dfile.encoding=windows-1251

Also I have quickly checked your tests for java library and I figured out that there are no one test which covers internalization aspects. I strongly recommend you to create these tests to avoid similar problems for the future.

Best regards, Vladimir Bukhtoyarov
Senior software engineer at DinoSystems
E-mail: Vladimir.Bukhtoyarov@nordigy.ru
Skype: live:fanat-tdd