### PR TITLE
pamGrant: remove existing auth from params.

### DIFF
--- a/java/src1/com/pubnub/api/PubnubCoreShared.java
+++ b/java/src1/com/pubnub/api/PubnubCoreShared.java
@@ -241,6 +241,7 @@ abstract class PubnubCoreShared extends PubnubCore {
                          boolean write, int ttl, Callback callback) {
         final Callback cb = getWrappedCallback(callback);
         Hashtable parameters = PubnubUtil.hashtableClone(params);
+        parameters.remove("auth");
 
         String r = (read) ? "1" : "0";
         String w = (write) ? "1" : "0";


### PR DESCRIPTION
If you have a `Pubnub` object on which you have set an auth key, and you attempt to call `pamGrant` _without_ an auth key, the copy of `params` will incorrectly contain `auth` equal to the auth key for the `Pubnub` object, but the signature will be generated without a key. This results in a 403 when the HTTP request is actually made to create the grant.

Removing the auth key immediately after copying `params` prevents this from occurring.