### PR TITLE
Replace commons lang method with own implementation

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -8,13 +8,6 @@
 
   <packaging>jar</packaging>
   <name>pubnub-android</name>
-  <dependencies>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.4</version>
-      </dependency>
-  </dependencies>
   <description>PubNub is a cross-platform client-to-client (1:1 and 1:many) push service in the cloud, capable of broadcasting real-time messages to millions of web and mobile clients simultaneously, in less than a quarter second!</description>
   <url>https://github.com/pubnub/java</url>
   <licenses>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -84,11 +84,6 @@
     </build>
     <dependencies>
         <dependency>
-	    <groupId>org.apache.commons</groupId>
-	    <artifactId>commons-lang3</artifactId>
-	    <version>3.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20090211</version>

--- a/java/src1/com/pubnub/api/PubnubUtil.java
+++ b/java/src1/com/pubnub/api/PubnubUtil.java
@@ -1,39 +1,130 @@
 package com.pubnub.api;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Locale;
 
 
 /**
  * PubnubUtil class provides utility methods like urlEncode etc
- * 
+ *
  * @author Pubnub
- * 
+ *
  */
 public class PubnubUtil extends PubnubUtilCore {
+    static final char[] HEX_DIGITS = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
     public static String escapeJava(String a) {
-        return StringEscapeUtils.escapeJava(a);
+//        return StringEscapeUtils.escapeJava(a);
+        StringBuilder result = new StringBuilder(a);
+        int len = a.length();
+        for (int i=0, j=0; i < len; i++, j++) {
+            final char in = a.charAt(i);
+            final char escaped = escapeJavaChar(in);
+            if (escaped != 0) {
+                result.insert(j++, '\\');
+                result.setCharAt(j, escaped);
+            } else {
+                int point = a.codePointAt(i);
+                j = unicodeEscape(result, point, j);
+                if (point > '\uffff') {
+                    // multi-char
+                    i++;
+                }
+            }
+        }
+        return result.toString();
     }
 
+    /**
+     * @return 0 if the char need not be escaped,
+     *  else the character that should replace `in`
+     *  after being escaped with a backslash.
+     */
+    private static char escapeJavaChar(char in) {
+        if (in == '"' || in == '\\') {
+            return in;
+        }
+
+        // JAVA_CTRL_CHARS_ESCAPE
+        if (in == '\b') {
+            return 'b';
+        } else if (in == '\n') {
+            return 'n';
+        } else if (in == '\t') {
+            return 't';
+        } else if (in == '\f') {
+            return 'f';
+        } else if (in == '\r') {
+            return 'r';
+        }
+
+        return 0;
+    }
+
+    /**
+     * Given a char, and its location in a StringBuilder,
+     *  replace it with an escaped unicode if necessary
+     * @return The new index into StringBuilder
+     */
+    private static int unicodeEscape(StringBuilder result, int in, int index) {
+        // utf8 within [32, 127] are fine
+        if (in >= 32 && in <= 127) {
+            return index;
+        }
+
+        if (in > '\uffff') {
+            final char[] surrogatePair = Character.toChars(in);
+            final String first = hex(surrogatePair[0]);
+            final String second = hex(surrogatePair[1]);
+
+            // ensure we have capacity to replace 2 chars
+            // (IE a surrogate pair) with \\u + first + \\u + second
+            result.ensureCapacity(result.capacity() + 2
+                    + first.length() + second.length());
+            result.delete(index, index + 2);
+            result.insert(index++, '\\');
+            result.insert(index++, 'u');
+            result.insert(index, first);
+            index += first.length();
+
+            result.insert(index++, '\\');
+            result.insert(index++, 'u');
+            result.insert(index, second);
+            index += second.length() - 1;
+        } else {
+            // ensure we have capacity to replace 1 char with 6
+            result.ensureCapacity(result.capacity() + 5);
+            result.deleteCharAt(index);
+            result.insert(index++, '\\');
+            result.insert(index++, 'u');
+            result.insert(index++, HEX_DIGITS[in >> 12 & 15]);
+            result.insert(index++, HEX_DIGITS[in >> 8 & 15]);
+            result.insert(index++, HEX_DIGITS[in >> 4 & 15]);
+            result.insert(index, HEX_DIGITS[in & 15]);
+        }
+
+        return index;
+    }
+
+    private static String hex(int codepoint) {
+        return Integer.toHexString(codepoint).toUpperCase(Locale.ENGLISH);
+    }
+
+
     public static String stringEscapeSlashes(String s, String a, String b) {
-		return s.replace(a, b);
+        return s.replace(a, b);
     }
     public static String stringReplaceAll(String s, String a, String b) {
-		return s.replaceAll(a, b);
+        return s.replaceAll(a, b);
     }
     /**
      * Returns encoded String
-     * 
+     *
      * @param sUrl
      *            , input string
      * @return , encoded string
@@ -52,7 +143,7 @@ public class PubnubUtil extends PubnubUtilCore {
 
     /**
      * Returns encoded String
-     * 
+     *
      * @param sUrl
      *            , input string
      * @return , encoded string
@@ -67,10 +158,10 @@ public class PubnubUtil extends PubnubUtilCore {
 
     /**
      * Convert input String to JSONObject, JSONArray, or String
-     * 
+     *
      * @param str
      *            JSON data in string format
-     * 
+     *
      * @return JSONArray or JSONObject or String
      */
     static Object stringToJSON(String str) {
@@ -93,3 +184,4 @@ public class PubnubUtil extends PubnubUtilCore {
         return str;
     }
 }
+

--- a/java/srcTest/com/pubnub/api/PubnubUtilTest.java
+++ b/java/srcTest/com/pubnub/api/PubnubUtilTest.java
@@ -1,0 +1,62 @@
+package com.pubnub.api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author dhleong
+ */
+public class PubnubUtilTest {
+    @Test
+    public void escapeSimple() {
+        assertEquals("well \\\"hello\\\" there",
+                PubnubUtil.escapeJava("well \"hello\" there"));
+
+        assertEquals("this\\\\that",
+                PubnubUtil.escapeJava("this\\that"));
+    }
+
+    @Test
+    public void escapeSequences() {
+        assertEquals("\\t",
+                PubnubUtil.escapeJava("\t"));
+
+        assertEquals("\\t\\b\\f\\n\\r",
+                PubnubUtil.escapeJava("\t\b\f\n\r"));
+
+        assertEquals("\\tt\\bb\\ff\\nn\\rr",
+                PubnubUtil.escapeJava("\tt\bb\ff\nn\rr"));
+    }
+
+    @Test
+    public void escapeUnicode() {
+        assertEquals("\\u001F", // 31, < 32
+                PubnubUtil.escapeJava("\u001f"));
+        assertEquals("\\u0080", // 128, > 128
+                PubnubUtil.escapeJava("\u0080"));
+
+        // but these are fine:
+        assertEquals("\u0020", // 32
+                PubnubUtil.escapeJava("\u0020"));
+        assertEquals("\u007f", // 127
+                PubnubUtil.escapeJava("\u007f"));
+    }
+
+    @Test
+    public void escapeSurrogatePairs() {
+        assertEquals("\\uD83D\\uDE00",
+                PubnubUtil.escapeJava("\uD83D\uDE00"));
+    }
+
+    @Test
+    public void escapeUnicodeMulti() {
+        assertEquals("\\u001F\\u0080\\u0081a\\u0082hi\\u0083",
+                PubnubUtil.escapeJava("\u001F\u0080\u0081a\u0082hi\u0083"));
+        
+        assertEquals("\\uD83D\\uDE00a\\u0082hi\\uD83D\\uDE00bye\\u0083",
+                PubnubUtil.escapeJava("\uD83D\uDE00a\u0082hi\uD83D\uDE00bye\u0083"));
+    }
+}
+
+


### PR DESCRIPTION
Update of #51 that re-implements `StringEscapeUtils#escapeJava()`.

@devendram Let me know if you find any problems with this implementation. It should be doing pretty much exactly what the commons lang implementation did. I've included some tests to verify the behavior.