### PR TITLE
Use current thread class loader to fetch SDK version

### DIFF
--- a/src/main/java/com/pubnub/api/PubNub.java
+++ b/src/main/java/com/pubnub/api/PubNub.java
@@ -232,7 +232,7 @@ public class PubNub {
      */
     private String fetchSDKVersion() {
         Properties prop = new Properties();
-        InputStream in = ClassLoader.getSystemClassLoader().getResourceAsStream("version.properties");
+        InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream("version.properties");
         try {
             prop.load(in);
         } catch (IOException e) {


### PR DESCRIPTION
Hey folks - excited to see the progress on the 4.0 SDK. I'm exploring the new API. I'm getting an NPE during initialization, though. `ClassLoader.getSystemClassLoader()` will return the wrong class loader on Android. I think we want to use the class loader of the current thread context.