### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/164fd518c314417e896b3de494ab75df)](https://www.codacy.com/app/PubNub/java?utm_source=github.com&utm_medium=referral&utm_content=pubnub/java&utm_campaign=Badge_Coverage)
 [![Download](https://api.bintray.com/packages/bintray/jcenter/com.pubnub%3Apubnub-gson/images/download.svg)](https://bintray.com/bintray/jcenter/com.pubnub%3Apubnub-gson/_latestVersion)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pubnub/pubnub-gson.svg)]()
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/PubNub/functions?utm_source=PubnubGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 ### [Documentation](https://www.pubnub.com/docs/java/pubnub-java-sdk-v4)
 


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out PubNub API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!