### PR TITLE
InterruptedException should be logged at trace level

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,7 +3,7 @@ version: 4.6.4
 schema: 1
 scm: github.com/pubnub/java
 files:
-  - build/libs/pubnub-gson-4.6.3-all.jar
+  - build/libs/pubnub-gson-4.6.4-all.jar
 changelog:
   - version: v4.6.4
     date:

--- a/src/main/java/com/pubnub/api/workers/SubscribeMessageWorker.java
+++ b/src/main/java/com/pubnub/api/workers/SubscribeMessageWorker.java
@@ -54,7 +54,7 @@ public class SubscribeMessageWorker implements Runnable {
                 this.processIncomingPayload(this.queue.take());
             } catch (InterruptedException e) {
                 this.isRunning = false;
-                log.warn("take message interrupted", e);
+                log.trace("take message interrupted", e);
             }
         }
     }


### PR DESCRIPTION
When shutting down and unsubscribing from channel the log currently logs WARN.
This should be avoided.

LOG ->
2017-06-17 18:19:46.253  WARN 85916 --- [       Thread-2] c.p.api.workers.SubscribeMessageWorker   : take message interrupted

java.lang.InterruptedException: null
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2048)
	at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
	at com.pubnub.api.workers.SubscribeMessageWorker.takeMessage(SubscribeMessageWorker.java:54)
	at com.pubnub.api.workers.SubscribeMessageWorker.run(SubscribeMessageWorker.java:45)
	at java.lang.Thread.run(Thread.java:745)