### PR TITLE
Fix threshold comparison

### DIFF
--- a/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
+++ b/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
@@ -263,7 +263,7 @@ public class SubscriptionManager {
                 }
 
                 Integer requestMessageCountThreshold = pubnub.getConfiguration().getRequestMessageCountThreshold();
-                if (requestMessageCountThreshold != null && requestMessageCountThreshold == result.getMessages().size()) {
+                if (requestMessageCountThreshold != null && requestMessageCountThreshold <= result.getMessages().size()) {
                     PNStatus pnStatus = createPublicStatus(status)
                             .category(PNStatusCategory.PNRequestMessageCountExceededCategory)
                             .error(false)

--- a/src/test/java/com/pubnub/api/managers/SubscriptionManagerTest.java
+++ b/src/test/java/com/pubnub/api/managers/SubscriptionManagerTest.java
@@ -144,7 +144,7 @@ public class SubscriptionManagerTest extends TestHarness {
     }
 
     @Test
-    public void testQueueNotificationsBuilder() {
+    public void testQueueNotificationsBuilderThresholdMatched() {
         pubnub.getConfiguration().setRequestMessageCountThreshold(1);
         final AtomicBoolean gotStatus = new AtomicBoolean();
         stubFor(get(urlPathEqualTo("/v2/subscribe/mySubscribeKey/ch2,ch1/0"))
@@ -167,6 +167,34 @@ public class SubscriptionManagerTest extends TestHarness {
             }
         });
 
+        pubnub.subscribe().channels(Arrays.asList("ch1", "ch2")).execute();
+
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAtomic(gotStatus, org.hamcrest.core.IsEqual.equalTo(true));
+    }
+
+    @Test
+    public void testQueueNotificationsBuilderThresholdExceeded() {
+        pubnub.getConfiguration().setRequestMessageCountThreshold(1);
+        final AtomicBoolean gotStatus = new AtomicBoolean();
+        stubFor(get(urlPathEqualTo("/v2/subscribe/mySubscribeKey/ch2,ch1/0"))
+            .willReturn(aResponse().withBody("{\"m\":[{\"a\":\"4\",\"b\":\"coolChannel\",\"c\":\"coolChannel\",\"d\":{\"text\":\"Message\"},\"f\":0,\"i\":\"Client-g5d4g\",\"k\":\"sub-c-4cec9f8e-01fa-11e6-8180-0619f8945a4f\",\"o\":{\"r\":2,\"t\":\"14737141991877032\"},\"p\":{\"r\":1,\"t\":\"14607577960925503\"}},{\"a\":\"5\",\"b\":\"coolChannel2\",\"c\":\"coolChannel2\",\"d\":{\"text\":\"Message2\"},\"f\":0,\"i\":\"Client-g5d4g\",\"k\":\"sub-c-4cec9f8e-01fa-11e6-8180-0619f8945a4g\",\"o\":{\"r\":2,\"t\":\"14737141991877033\"},\"p\":{\"r\":1,\"t\":\"14607577960925504\"}}],\"t\":{\"r\":1,\"t\":\"14607577960932487\"}}")));
+
+        pubnub.addListener(new SubscribeCallback() {
+            @Override
+            public void status(PubNub pubnub, PNStatus status) {
+                if (status.getCategory() == PNStatusCategory.PNRequestMessageCountExceededCategory) {
+                    gotStatus.set(true);
+                }
+            }
+
+            @Override
+            public void message(PubNub pubnub, PNMessageResult message) {
+            }
+
+            @Override
+            public void presence(PubNub pubnub, PNPresenceEventResult presence) {
+            }
+        });
 
         pubnub.subscribe().channels(Arrays.asList("ch1", "ch2")).execute();
 

--- a/src/test/java/com/pubnub/api/managers/SubscriptionManagerTest.java
+++ b/src/test/java/com/pubnub/api/managers/SubscriptionManagerTest.java
@@ -144,6 +144,64 @@ public class SubscriptionManagerTest extends TestHarness {
     }
 
     @Test
+    public void testQueueNotificationsBuilderNoThresholdSpecified() {
+        pubnub.getConfiguration().setRequestMessageCountThreshold(null);
+        final AtomicBoolean gotStatus = new AtomicBoolean();
+        stubFor(get(urlPathEqualTo("/v2/subscribe/mySubscribeKey/ch2,ch1/0"))
+            .willReturn(aResponse().withBody("{\"t\":{\"t\":\"14607577960932487\",\"r\":1},\"m\":[{\"a\":\"4\",\"f\":0,\"i\":\"Client-g5d4g\",\"p\":{\"t\":\"14607577960925503\",\"r\":1},\"o\":{\"t\":\"14737141991877032\",\"r\":2},\"k\":\"sub-c-4cec9f8e-01fa-11e6-8180-0619f8945a4f\",\"c\":\"coolChannel\",\"d\":{\"text\":\"Message\"},\"b\":\"coolChannel\"}]}")));
+
+        pubnub.addListener(new SubscribeCallback() {
+            @Override
+            public void status(PubNub pubnub, PNStatus status) {
+                if (status.getCategory() == PNStatusCategory.PNRequestMessageCountExceededCategory) {
+                    gotStatus.set(true);
+                }
+            }
+
+            @Override
+            public void message(PubNub pubnub, PNMessageResult message) {
+            }
+
+            @Override
+            public void presence(PubNub pubnub, PNPresenceEventResult presence) {
+            }
+        });
+
+        pubnub.subscribe().channels(Arrays.asList("ch1", "ch2")).execute();
+
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAtomic(gotStatus, org.hamcrest.core.IsEqual.equalTo(false));
+    }
+
+    @Test
+    public void testQueueNotificationsBuilderBelowThreshold() {
+        pubnub.getConfiguration().setRequestMessageCountThreshold(10);
+        final AtomicBoolean gotStatus = new AtomicBoolean();
+        stubFor(get(urlPathEqualTo("/v2/subscribe/mySubscribeKey/ch2,ch1/0"))
+            .willReturn(aResponse().withBody("{\"t\":{\"t\":\"14607577960932487\",\"r\":1},\"m\":[{\"a\":\"4\",\"f\":0,\"i\":\"Client-g5d4g\",\"p\":{\"t\":\"14607577960925503\",\"r\":1},\"o\":{\"t\":\"14737141991877032\",\"r\":2},\"k\":\"sub-c-4cec9f8e-01fa-11e6-8180-0619f8945a4f\",\"c\":\"coolChannel\",\"d\":{\"text\":\"Message\"},\"b\":\"coolChannel\"}]}")));
+
+        pubnub.addListener(new SubscribeCallback() {
+            @Override
+            public void status(PubNub pubnub, PNStatus status) {
+                if (status.getCategory() == PNStatusCategory.PNRequestMessageCountExceededCategory) {
+                    gotStatus.set(true);
+                }
+            }
+
+            @Override
+            public void message(PubNub pubnub, PNMessageResult message) {
+            }
+
+            @Override
+            public void presence(PubNub pubnub, PNPresenceEventResult presence) {
+            }
+        });
+
+        pubnub.subscribe().channels(Arrays.asList("ch1", "ch2")).execute();
+
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAtomic(gotStatus, org.hamcrest.core.IsEqual.equalTo(false));
+    }
+
+    @Test
     public void testQueueNotificationsBuilderThresholdMatched() {
         pubnub.getConfiguration().setRequestMessageCountThreshold(1);
         final AtomicBoolean gotStatus = new AtomicBoolean();


### PR DESCRIPTION
I was only seeing a `PNStatus` with `PNRequestMessageCountExceededCategory` if the exact threshold value was emitted. I'm pretty sure the intention of this category is to announce any time the threshold is hit _or exceeded_.