### PR TITLE
Fix Google App Engine support

### DIFF
--- a/src/main/java/com/pubnub/api/endpoints/vendor/AppEngineFactory.java
+++ b/src/main/java/com/pubnub/api/endpoints/vendor/AppEngineFactory.java
@@ -1,8 +1,20 @@
 package com.pubnub.api.endpoints.vendor;
 
+import com.pubnub.api.PubNub;
+import com.pubnub.api.PubNubException;
+import com.pubnub.api.PubNubUtil;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.extern.java.Log;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Headers;
+import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
 import okhttp3.Request;
@@ -12,16 +24,14 @@ import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.Okio;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-
-
+@Log
 public class AppEngineFactory implements Call {
     private Request request;
+    private PubNub pubNub;
 
-    AppEngineFactory(Request request) {
+    AppEngineFactory(Request request, PubNub pubNub) {
         this.request = request;
+        this.pubNub = pubNub;
     }
 
     @Override
@@ -31,6 +41,8 @@ public class AppEngineFactory implements Call {
 
     @Override
     public Response execute() throws IOException {
+        request = signIfNecessary(request); // We need this since we bypass the signature interceptor
+
         URL url = request.url().url();
         final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setUseCaches(false);
@@ -83,6 +95,53 @@ public class AppEngineFactory implements Call {
         return response;
     }
 
+    // TODO: This should probably go in a util file so we don't have copied code from SignatureInterceptor
+    public Request signIfNecessary(Request request) {
+        // only sign if we have a secret key in place.
+        if (this.pubNub.getConfiguration().getSecretKey() == null) {
+            return request;
+        }
+
+        HttpUrl url = request.url();
+        String requestURL = url.encodedPath();
+        int timestamp = this.pubNub.getTimestamp();
+        Map<String, String> queryParams = new HashMap<>();
+        String signature = "";
+
+        for (String queryKey: url.queryParameterNames()) {
+            queryParams.put(queryKey, url.queryParameter(queryKey));
+        }
+
+        queryParams.put("timestamp", String.valueOf(timestamp));
+
+        String signInput = pubNub.getConfiguration().getSubscribeKey() + "\n"
+                + pubNub.getConfiguration().getPublishKey() + "\n";
+
+        if (requestURL.startsWith("/v1/auth/audit")) {
+            signInput += "audit" + "\n";
+        } else if (requestURL.startsWith("/v1/auth/grant")) {
+            signInput += "grant" + "\n";
+        } else {
+            signInput += requestURL + "\n";
+        }
+
+        signInput += PubNubUtil.preparePamArguments(queryParams);
+
+        try {
+            signature = PubNubUtil.signSHA256(pubNub.getConfiguration().getSecretKey(), signInput);
+        } catch (PubNubException e) {
+            log.warning("signature failed on SignatureInterceptor: " + e.toString());
+        }
+
+        HttpUrl rebuiltUrl = url.newBuilder()
+                .addQueryParameter("timestamp", String.valueOf(timestamp))
+                .addQueryParameter("signature", signature)
+                .build();
+
+        request = request.newBuilder().url(rebuiltUrl).build();
+        return request;
+    }
+
     @Override
     public void enqueue(Callback responseCallback) {
 
@@ -113,9 +172,15 @@ public class AppEngineFactory implements Call {
     }
 
     public static class Factory implements Call.Factory {
+        private PubNub pubNub;
+
+        public Factory(PubNub pubNub) {
+            this.pubNub = pubNub;
+        }
+
         @Override
         public Call newCall(Request request) {
-            return new AppEngineFactory(request);
+            return new AppEngineFactory(request, pubNub);
         }
     }
 }

--- a/src/main/java/com/pubnub/api/managers/RetrofitManager.java
+++ b/src/main/java/com/pubnub/api/managers/RetrofitManager.java
@@ -6,14 +6,15 @@ import com.pubnub.api.PubNub;
 import com.pubnub.api.endpoints.vendor.AppEngineFactory;
 import com.pubnub.api.enums.PNLogVerbosity;
 import com.pubnub.api.interceptors.SignatureInterceptor;
-import lombok.Getter;
-import okhttp3.OkHttpClient;
-import okhttp3.logging.HttpLoggingInterceptor;
-import retrofit2.Retrofit;
 
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import lombok.Getter;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
 
 public class RetrofitManager {
 
@@ -32,15 +33,17 @@ public class RetrofitManager {
 
         this.signatureInterceptor = new SignatureInterceptor(pubNubInstance);
 
-        this.transactionClientInstance = createOkHttpClient(
-                this.pubnub.getConfiguration().getNonSubscribeRequestTimeout(),
-                this.pubnub.getConfiguration().getConnectTimeout()
-        );
+        if (!pubNubInstance.getConfiguration().isGoogleAppEngineNetworking()) {
+            this.transactionClientInstance = createOkHttpClient(
+                    this.pubnub.getConfiguration().getNonSubscribeRequestTimeout(),
+                    this.pubnub.getConfiguration().getConnectTimeout()
+            );
 
-        this.subscriptionClientInstance = createOkHttpClient(
-                this.pubnub.getConfiguration().getSubscribeTimeout(),
-                this.pubnub.getConfiguration().getConnectTimeout()
-        );
+            this.subscriptionClientInstance = createOkHttpClient(
+                    this.pubnub.getConfiguration().getSubscribeTimeout(),
+                    this.pubnub.getConfiguration().getConnectTimeout()
+            );
+        }
 
         this.transactionInstance = createRetrofit(this.transactionClientInstance);
         this.subscriptionInstance = createRetrofit(this.subscriptionClientInstance);
@@ -95,19 +98,28 @@ public class RetrofitManager {
         Retrofit.Builder retrofitBuilder = new Retrofit.Builder();
 
         if (pubnub.getConfiguration().isGoogleAppEngineNetworking()) {
-            retrofitBuilder.callFactory(new AppEngineFactory.Factory());
+            retrofitBuilder.callFactory(new AppEngineFactory.Factory(pubnub));
         }
 
-        return retrofitBuilder
+        retrofitBuilder = retrofitBuilder
                 .baseUrl(pubnub.getBaseUrl())
-                .addConverterFactory(this.pubnub.getMapper().getConverterFactory())
-                .client(client)
-                .build();
+                .addConverterFactory(this.pubnub.getMapper().getConverterFactory());
+
+        if (!pubnub.getConfiguration().isGoogleAppEngineNetworking()) {
+             retrofitBuilder = retrofitBuilder
+                     .client(client);
+        }
+
+        return retrofitBuilder.build();
     }
 
     public void destroy() {
-        closeExecutor(this.transactionClientInstance);
-        closeExecutor(this.subscriptionClientInstance);
+        if (this.transactionClientInstance != null) {
+            closeExecutor(this.transactionClientInstance);
+        }
+        if (this.subscriptionClientInstance != null) {
+            closeExecutor(this.subscriptionClientInstance);
+        }
     }
 
     private void closeExecutor(OkHttpClient client) {


### PR DESCRIPTION
Google App Engine support does not appear to have been working since adding the PAM (due to OkHttpClient dependency). This is fixed.