### PR TITLE
Add forceDestroy method

### DIFF
--- a/src/main/java/com/pubnub/api/PubNub.java
+++ b/src/main/java/com/pubnub/api/PubNub.java
@@ -218,7 +218,7 @@ public class PubNub {
      * @param inputString String to be encrypted
      * @return String containing the encryption of inputString using cipherKey
      */
-    public  String encrypt(String inputString) throws PubNubException {
+    public String encrypt(String inputString) throws PubNubException {
         if (inputString == null) {
             throw PubNubException.builder().pubnubError(PubNubErrorBuilder.PNERROBJ_INVALID_ARGUMENTS).build();
         }
@@ -250,14 +250,14 @@ public class PubNub {
      * @return instance uuid.
      */
     public String getInstanceId() {
-        return  instanceId;
+        return instanceId;
     }
 
     /**
      * @return request uuid.
      */
     public String getRequestId() {
-        return  UUID.randomUUID().toString();
+        return UUID.randomUUID().toString();
     }
 
     /**
@@ -276,12 +276,24 @@ public class PubNub {
     }
 
     /**
-     *  Destroy the SDK to evict the connection pools.
+     * Destroy the SDK to cancel all ongoing requests and stop heartbeat timer.
      */
     public void destroy() {
         try {
-            subscriptionManager.destroy();
-            retrofitManager.destroy();
+            subscriptionManager.destroy(false);
+            retrofitManager.destroy(false);
+        } catch (Exception error) {
+            //
+        }
+    }
+
+    /**
+     * Force destroy the SDK to evict the connection pools and close executors.
+     */
+    public void forceDestroy() {
+        try {
+            subscriptionManager.destroy(true);
+            retrofitManager.destroy(true);
         } catch (Exception error) {
             //
         }

--- a/src/main/java/com/pubnub/api/managers/RetrofitManager.java
+++ b/src/main/java/com/pubnub/api/managers/RetrofitManager.java
@@ -20,6 +20,7 @@ import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
 
 import java.util.Collections;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class RetrofitManager {
@@ -144,17 +145,21 @@ public class RetrofitManager {
     }
 
 
-
-    public void destroy() {
+    public void destroy(boolean force) {
         if (this.transactionClientInstance != null) {
-            closeExecutor(this.transactionClientInstance);
+            closeExecutor(this.transactionClientInstance, force);
         }
         if (this.subscriptionClientInstance != null) {
-            closeExecutor(this.subscriptionClientInstance);
+            closeExecutor(this.subscriptionClientInstance, force);
         }
     }
 
-    private void closeExecutor(OkHttpClient client) {
+    private void closeExecutor(OkHttpClient client, boolean force) {
         client.dispatcher().cancelAll();
+        if (force) {
+            client.connectionPool().evictAll();
+            ExecutorService executorService = client.dispatcher().executorService();
+            executorService.shutdown();
+        }
     }
 }

--- a/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
+++ b/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
@@ -146,8 +146,10 @@ public class SubscriptionManager {
         consumerThread.interrupt();
     }
 
-    public synchronized void destroy() {
+    public synchronized void destroy(boolean forceDestroy) {
         this.disconnect();
+        if (forceDestroy)
+            consumerThread.interrupt();
     }
 
     public synchronized void adaptStateBuilder(StateOperation stateOperation) {

--- a/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
+++ b/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
@@ -148,8 +148,9 @@ public class SubscriptionManager {
 
     public synchronized void destroy(boolean forceDestroy) {
         this.disconnect();
-        if (forceDestroy)
+        if (forceDestroy){
             consumerThread.interrupt();
+        }
     }
 
     public synchronized void adaptStateBuilder(StateOperation stateOperation) {

--- a/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
+++ b/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
@@ -148,7 +148,7 @@ public class SubscriptionManager {
 
     public synchronized void destroy(boolean forceDestroy) {
         this.disconnect();
-        if (forceDestroy){
+        if (forceDestroy) {
             consumerThread.interrupt();
         }
     }


### PR DESCRIPTION
Introduce a new `forceDestroy()` method, which evicts the connection pools and closes OkHttp executors.