### PR TITLE
Fix a bug where TelemetryManager prevented PubNub from destroying

### DIFF
--- a/src/main/java/com/pubnub/api/PubNub.java
+++ b/src/main/java/com/pubnub/api/PubNub.java
@@ -294,6 +294,7 @@ public class PubNub {
         try {
             subscriptionManager.destroy(true);
             retrofitManager.destroy(true);
+            telemetryManager.stopCleanUpTimer();
         } catch (Exception error) {
             //
         }

--- a/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
+++ b/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
@@ -149,7 +149,9 @@ public class SubscriptionManager {
     public synchronized void destroy(boolean forceDestroy) {
         this.disconnect();
         if (forceDestroy) {
-            consumerThread.interrupt();
+            if (consumerThread != null) {
+                consumerThread.interrupt();
+            }
         }
     }
 

--- a/src/main/java/com/pubnub/api/managers/TelemetryManager.java
+++ b/src/main/java/com/pubnub/api/managers/TelemetryManager.java
@@ -97,7 +97,7 @@ public class TelemetryManager {
         }, interval, interval);
     }
 
-    private void stopCleanUpTimer() {
+    public void stopCleanUpTimer() {
         if (this.timer != null) {
             this.timer.cancel();
             this.timer = null;


### PR DESCRIPTION
Fix a bug where TelemetryManager prevented PubNub from destroying