### PR TITLE
Explicitly use the latest OkHttp version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,14 @@ repositories {
 
 
 dependencies {
-    compile group: 'com.squareup.retrofit2', name: 'retrofit', version:'2.3.0'
+    compile(group: 'com.squareup.retrofit2', name: 'retrofit', version: '2.3.0') {
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    }
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.9.1'
 
-    compile group: 'com.squareup.okhttp3', name: 'logging-interceptor', version:'3.9.1'
-    compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.22'
+    compile group: 'com.squareup.okhttp3', name: 'logging-interceptor', version: '3.9.1'
+
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.22'
 
     // jackson
     // compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.7.3'


### PR DESCRIPTION
Explicitly use the latest OkHttp, instead of relying to embedded version inside Retrofit