### PR TITLE
Replace PNCallback with an Interface

### DIFF
--- a/src/main/java/com/pubnub/api/callbacks/PNCallback.java
+++ b/src/main/java/com/pubnub/api/callbacks/PNCallback.java
@@ -1,11 +1,11 @@
 package com.pubnub.api.callbacks;
 
 
-import com.pubnub.api.models.consumer.PNStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class PNCallback<@Nullable X> {
-    public abstract void onResponse(@Nullable X result, @NotNull PNStatus status);
+/**
+ * Left for backwards compatibility. Replace with {@link PNResultCallback}.
+ */
+@Deprecated
+public abstract class PNCallback<@Nullable X> implements PNResultCallback<X> {
 }
-

--- a/src/main/java/com/pubnub/api/callbacks/PNResultCallback.java
+++ b/src/main/java/com/pubnub/api/callbacks/PNResultCallback.java
@@ -1,0 +1,10 @@
+package com.pubnub.api.callbacks;
+
+import com.pubnub.api.models.consumer.PNStatus;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface PNResultCallback<@Nullable X> {
+   void onResponse(@Nullable X result, @NotNull PNStatus status);
+}

--- a/src/main/java/com/pubnub/api/callbacks/TimeCallback.java
+++ b/src/main/java/com/pubnub/api/callbacks/TimeCallback.java
@@ -2,5 +2,5 @@ package com.pubnub.api.callbacks;
 
 import com.pubnub.api.models.consumer.PNTimeResult;
 
-public abstract class TimeCallback extends PNCallback<PNTimeResult> {
+public abstract class TimeCallback implements PNResultCallback<PNTimeResult> {
 }

--- a/src/main/java/com/pubnub/api/callbacks/WhereNowCallback.java
+++ b/src/main/java/com/pubnub/api/callbacks/WhereNowCallback.java
@@ -3,5 +3,5 @@ package com.pubnub.api.callbacks;
 import com.pubnub.api.models.consumer.presence.PNWhereNowResult;
 
 
-public abstract class WhereNowCallback extends PNCallback<PNWhereNowResult> {
+public abstract class WhereNowCallback implements PNResultCallback<PNWhereNowResult> {
 }

--- a/src/main/java/com/pubnub/api/endpoints/Endpoint.java
+++ b/src/main/java/com/pubnub/api/endpoints/Endpoint.java
@@ -6,7 +6,7 @@ import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
 import com.pubnub.api.PubNubUtil;
 import com.pubnub.api.builder.PubNubErrorBuilder;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.enums.PNStatusCategory;
 import com.pubnub.api.managers.MapperManager;
@@ -49,7 +49,7 @@ public abstract class Endpoint<Input, Output> {
     private TelemetryManager telemetryManager;
 
     @Getter(AccessLevel.NONE)
-    private PNCallback<Output> cachedCallback;
+    private PNResultCallback<Output> cachedCallback;
 
     @Getter(AccessLevel.NONE)
     private Call<Input> call;
@@ -127,7 +127,7 @@ public abstract class Endpoint<Input, Output> {
         return response;
     }
 
-    public void async(@NotNull final PNCallback<Output> callback) {
+    public void async(@NotNull final PNResultCallback<Output> callback) {
         cachedCallback = callback;
 
         try {

--- a/src/main/java/com/pubnub/api/managers/ReconnectionManager.java
+++ b/src/main/java/com/pubnub/api/managers/ReconnectionManager.java
@@ -1,7 +1,7 @@
 package com.pubnub.api.managers;
 
 import com.pubnub.api.PubNub;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.callbacks.ReconnectionCallback;
 import com.pubnub.api.enums.PNReconnectionPolicy;
 import com.pubnub.api.models.consumer.PNStatus;
@@ -106,7 +106,7 @@ public class ReconnectionManager {
 
     private void callTime() {
         try {
-            pubnub.time().async(new PNCallback<PNTimeResult>() {
+            pubnub.time().async(new PNResultCallback<PNTimeResult>() {
                 @Override
                 public void onResponse(PNTimeResult result, @NotNull PNStatus status) {
                     if (!status.isError()) {

--- a/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
+++ b/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
@@ -5,7 +5,7 @@ import com.pubnub.api.builder.dto.PresenceOperation;
 import com.pubnub.api.builder.dto.StateOperation;
 import com.pubnub.api.builder.dto.SubscribeOperation;
 import com.pubnub.api.builder.dto.UnsubscribeOperation;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.callbacks.ReconnectionCallback;
 import com.pubnub.api.callbacks.SubscribeCallback;
 import com.pubnub.api.endpoints.presence.Heartbeat;
@@ -190,7 +190,7 @@ public class SubscriptionManager {
         if (!this.pubnub.getConfiguration().isSupressLeaveEvents() && !presenceOperation.isConnected()) {
             new Leave(pubnub, this.telemetryManager, this.retrofitManager)
                     .channels(presenceOperation.getChannels()).channelGroups(presenceOperation.getChannelGroups())
-                    .async(new PNCallback<Boolean>() {
+                    .async(new PNResultCallback<Boolean>() {
                         @Override
                         public void onResponse(Boolean result, @NotNull PNStatus status) {
                             listenerManager.announce(status);
@@ -209,7 +209,7 @@ public class SubscriptionManager {
         if (!this.pubnub.getConfiguration().isSupressLeaveEvents()) {
             new Leave(pubnub, this.telemetryManager, this.retrofitManager)
                     .channels(unsubscribeOperation.getChannels()).channelGroups(unsubscribeOperation.getChannelGroups())
-                    .async(new PNCallback<Boolean>() {
+                    .async(new PNResultCallback<Boolean>() {
                         @Override
                         public void onResponse(Boolean result, @NotNull PNStatus status) {
                             listenerManager.announce(status);
@@ -276,7 +276,7 @@ public class SubscriptionManager {
                 .filterExpression(pubnub.getConfiguration().getFilterExpression())
                 .state(stateStorage);
 
-        subscribeCall.async(new PNCallback<SubscribeEnvelope>() {
+        subscribeCall.async(new PNResultCallback<SubscribeEnvelope>() {
             @Override
             public void onResponse(SubscribeEnvelope result, @NotNull PNStatus status) {
                 if (status.isError()) {
@@ -374,7 +374,7 @@ public class SubscriptionManager {
                 .channels(channels)
                 .channelGroups(groups);
 
-        heartbeatCall.async(new PNCallback<Boolean>() {
+        heartbeatCall.async(new PNResultCallback<Boolean>() {
             @Override
             public void onResponse(Boolean result, @NotNull PNStatus status) {
                 PNHeartbeatNotificationOptions heartbeatVerbosity =

--- a/src/test/java/com/pubnub/api/endpoints/HistoryEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/HistoryEndpointTest.java
@@ -4,10 +4,11 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNStatus;
 import com.pubnub.api.models.consumer.history.PNHistoryResult;
+
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -371,7 +372,7 @@ public class HistoryEndpointTest extends TestHarness {
                 .willReturn(aResponse().withBody(pubnub.getMapper().toJson(testArray))));
 
         final AtomicInteger atomic = new AtomicInteger(0);
-        partialHistory.channel("niceChannel").includeTimetoken(true).async(new PNCallback<PNHistoryResult>() {
+        partialHistory.channel("niceChannel").includeTimetoken(true).async(new PNResultCallback<PNHistoryResult>() {
             @Override
             public void onResponse(PNHistoryResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNHistoryOperation) {

--- a/src/test/java/com/pubnub/api/endpoints/access/GrantEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/access/GrantEndpointTest.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNStatus;
@@ -977,7 +977,7 @@ public class GrantEndpointTest extends TestHarness {
                         "Manager\",\"status\":200}")));
 
         partialGrant.authKeys(Collections.singletonList("key1")).channels(Collections.singletonList("ch1")).async(
-                new PNCallback<PNAccessManagerGrantResult>() {
+                new PNResultCallback<PNAccessManagerGrantResult>() {
                     @Override
                     public void onResponse(PNAccessManagerGrantResult result, @NotNull PNStatus status) {
                         if (status != null && status.getOperation() == PNOperationType.PNAccessManagerGrant) {
@@ -1131,7 +1131,7 @@ public class GrantEndpointTest extends TestHarness {
                         "\"channel\":\"ch1\",\"auths\":{\"key1\":{\"r\":0,\"w\":0,\"m\":0}}},\"service\":\"Access " +
                         "Manager\",\"status\":200}")));
 
-        partialGrant.channels(Collections.singletonList("ch1")).async(new PNCallback<PNAccessManagerGrantResult>() {
+        partialGrant.channels(Collections.singletonList("ch1")).async(new PNResultCallback<PNAccessManagerGrantResult>() {
             @Override
             public void onResponse(PNAccessManagerGrantResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNAccessManagerGrant

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/AddChannelChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/AddChannelChannelGroupEndpointTest.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNStatus;
@@ -110,7 +110,7 @@ public class AddChannelChannelGroupEndpointTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        partialAddChannelChannelGroup.channelGroup("groupA").channels(Arrays.asList("ch1", "ch2")).async(new PNCallback<PNChannelGroupsAddChannelResult>() {
+        partialAddChannelChannelGroup.channelGroup("groupA").channels(Arrays.asList("ch1", "ch2")).async(new PNResultCallback<PNChannelGroupsAddChannelResult>() {
             @Override
             public void onResponse(PNChannelGroupsAddChannelResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNAddChannelsToGroupOperation) {
@@ -130,7 +130,7 @@ public class AddChannelChannelGroupEndpointTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        partialAddChannelChannelGroup.channelGroup("groupA").channels(Arrays.asList("ch1", "ch2")).async(new PNCallback<PNChannelGroupsAddChannelResult>() {
+        partialAddChannelChannelGroup.channelGroup("groupA").channels(Arrays.asList("ch1", "ch2")).async(new PNResultCallback<PNChannelGroupsAddChannelResult>() {
             @Override
             public void onResponse(PNChannelGroupsAddChannelResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNAddChannelsToGroupOperation) {

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/AllChannelsChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/AllChannelsChannelGroupEndpointTest.java
@@ -4,11 +4,12 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNStatus;
 import com.pubnub.api.models.consumer.channel_group.PNChannelGroupsAllChannelsResult;
+
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -120,7 +121,7 @@ public class AllChannelsChannelGroupEndpointTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        partialAllChannelsChannelGroup.channelGroup("groupA").async(new PNCallback<PNChannelGroupsAllChannelsResult>() {
+        partialAllChannelsChannelGroup.channelGroup("groupA").async(new PNResultCallback<PNChannelGroupsAllChannelsResult>() {
             @Override
             public void onResponse(PNChannelGroupsAllChannelsResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNChannelsForGroupOperation) {

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/DeleteChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/DeleteChannelGroupEndpointTest.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNStatus;
@@ -98,7 +98,7 @@ public class DeleteChannelGroupEndpointTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        partialDeleteChannelGroup.channelGroup("groupA").async(new PNCallback<PNChannelGroupsDeleteGroupResult>() {
+        partialDeleteChannelGroup.channelGroup("groupA").async(new PNResultCallback<PNChannelGroupsDeleteGroupResult>() {
             @Override
             public void onResponse(PNChannelGroupsDeleteGroupResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNRemoveGroupOperation) {

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/ListAllChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/ListAllChannelGroupEndpointTest.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNStatus;
@@ -108,7 +108,7 @@ public class ListAllChannelGroupEndpointTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        partialChannelGroup.async(new PNCallback<PNChannelGroupsListAllResult>() {
+        partialChannelGroup.async(new PNResultCallback<PNChannelGroupsListAllResult>() {
             @Override
             public void onResponse(PNChannelGroupsListAllResult result, @NotNull PNStatus status) {
                 if (status.getOperation() == PNOperationType.PNChannelGroupsOperation) {

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/RemoveChannelChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/RemoveChannelChannelGroupEndpointTest.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNStatus;
@@ -100,7 +100,7 @@ public class RemoveChannelChannelGroupEndpointTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        partialRemoveChannelChannelGroup.channelGroup("groupA").channels(Arrays.asList("ch1", "ch2")).async(new PNCallback<PNChannelGroupsRemoveChannelResult>() {
+        partialRemoveChannelChannelGroup.channelGroup("groupA").channels(Arrays.asList("ch1", "ch2")).async(new PNResultCallback<PNChannelGroupsRemoveChannelResult>() {
             @Override
             public void onResponse(PNChannelGroupsRemoveChannelResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNRemoveChannelsFromGroupOperation) {

--- a/src/test/java/com/pubnub/api/endpoints/presence/GetStateEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/presence/GetStateEndpointTest.java
@@ -5,11 +5,12 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.gson.JsonElement;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNStatus;
 import com.pubnub.api.models.consumer.presence.PNGetStateResult;
+
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -231,7 +232,7 @@ public class GetStateEndpointTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        partialGetState.channels(Collections.singletonList("testChannel")).uuid("sampleUUID").async(new PNCallback<PNGetStateResult>() {
+        partialGetState.channels(Collections.singletonList("testChannel")).uuid("sampleUUID").async(new PNResultCallback<PNGetStateResult>() {
             @Override
             public void onResponse(PNGetStateResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNGetState) {

--- a/src/test/java/com/pubnub/api/endpoints/presence/HereNowEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/presence/HereNowEndpointTest.java
@@ -4,11 +4,12 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNStatus;
 import com.pubnub.api.models.consumer.presence.PNHereNowResult;
+
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -293,7 +294,7 @@ public class HereNowEndpointTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        partialHereNow.async(new PNCallback<PNHereNowResult>() {
+        partialHereNow.async(new PNResultCallback<PNHereNowResult>() {
             @Override
             public void onResponse(PNHereNowResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNHereNowOperation) {

--- a/src/test/java/com/pubnub/api/endpoints/presence/LeaveTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/presence/LeaveTest.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.managers.RetrofitManager;
 import com.pubnub.api.models.consumer.PNStatus;
@@ -100,7 +100,7 @@ public class LeaveTest extends TestHarness {
                 .willReturn(aResponse().withBody("{\"status\": 200, \"message\": \"OK\", \"service\": \"Presence\", " +
                         "\"action\": \"leave\"}")));
 
-        instance.channels(Arrays.asList("coolChannel", "coolChannel2")).channelGroups(Arrays.asList("cg1")).async(new PNCallback<Boolean>() {
+        instance.channels(Arrays.asList("coolChannel", "coolChannel2")).channelGroups(Arrays.asList("cg1")).async(new PNResultCallback<Boolean>() {
             @Override
             public void onResponse(Boolean result, @NotNull PNStatus status) {
                 assertEquals(status.getAffectedChannels().get(0), "coolChannel");

--- a/src/test/java/com/pubnub/api/endpoints/pubsub/PublishTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/pubsub/PublishTest.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.models.consumer.PNPublishResult;
@@ -355,7 +355,7 @@ public class PublishTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        instance.async(new PNCallback<PNPublishResult>() {
+        instance.async(new PNResultCallback<PNPublishResult>() {
             @Override
             public void onResponse(PNPublishResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNPublishOperation) {

--- a/src/test/java/com/pubnub/api/endpoints/pubsub/SignalTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/pubsub/SignalTest.java
@@ -5,7 +5,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.callbacks.SubscribeCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
@@ -107,7 +107,7 @@ public class SignalTest extends TestHarness {
         pubNub.signal()
                 .channel("coolChannel")
                 .message(payload)
-                .async(new PNCallback<PNPublishResult>() {
+                .async(new PNResultCallback<PNPublishResult>() {
                     @Override
                     public void onResponse(PNPublishResult result, @NotNull PNStatus status) {
                         assertFalse(status.isError());

--- a/src/test/java/com/pubnub/api/endpoints/push/ListPushProvisionsTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/push/ListPushProvisionsTest.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.enums.PNPushType;
@@ -112,7 +112,7 @@ public class ListPushProvisionsTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        instance.deviceId("niceDevice").pushType(PNPushType.APNS).async(new PNCallback<PNPushListProvisionsResult>() {
+        instance.deviceId("niceDevice").pushType(PNPushType.APNS).async(new PNResultCallback<PNPushListProvisionsResult>() {
             @Override
             public void onResponse(PNPushListProvisionsResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNPushNotificationEnabledChannelsOperation) {

--- a/src/test/java/com/pubnub/api/endpoints/push/ModifyPushChannelsForDeviceTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/push/ModifyPushChannelsForDeviceTest.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNOperationType;
 import com.pubnub.api.enums.PNPushType;
@@ -114,7 +114,7 @@ public class ModifyPushChannelsForDeviceTest extends TestHarness {
 
         final AtomicInteger atomic = new AtomicInteger(0);
 
-        instance.deviceId("niceDevice").pushType(PNPushType.MPNS).async(new PNCallback<PNPushRemoveAllChannelsResult>() {
+        instance.deviceId("niceDevice").pushType(PNPushType.MPNS).async(new PNResultCallback<PNPushRemoveAllChannelsResult>() {
             @Override
             public void onResponse(PNPushRemoveAllChannelsResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNRemoveAllPushNotificationsOperation) {
@@ -250,7 +250,7 @@ public class ModifyPushChannelsForDeviceTest extends TestHarness {
 
         instanceAdd.deviceId("niceDevice").pushType(PNPushType.MPNS)
                 .channels(Arrays.asList("ch1", "ch2", "ch3"))
-                .async(new PNCallback<PNPushAddChannelResult>() {
+                .async(new PNResultCallback<PNPushAddChannelResult>() {
                     @Override
                     public void onResponse(PNPushAddChannelResult result, @NotNull PNStatus status) {
                         if (status != null && status.getOperation() == PNOperationType.PNPushNotificationEnabledChannelsOperation) {
@@ -412,7 +412,7 @@ public class ModifyPushChannelsForDeviceTest extends TestHarness {
         final AtomicInteger atomic = new AtomicInteger(0);
 
         instanceRemove.deviceId("niceDevice").pushType(PNPushType.MPNS)
-                .channels(Arrays.asList("chr1", "chr2", "chr3")).async(new PNCallback<PNPushRemoveChannelResult>() {
+                .channels(Arrays.asList("chr1", "chr2", "chr3")).async(new PNResultCallback<PNPushRemoveChannelResult>() {
             @Override
             public void onResponse(PNPushRemoveChannelResult result, @NotNull PNStatus status) {
                 if (status != null && status.getOperation() == PNOperationType.PNRemovePushNotificationsFromChannelsOperation) {

--- a/src/test/java/com/pubnub/api/managers/SubscriptionManagerTest.java
+++ b/src/test/java/com/pubnub/api/managers/SubscriptionManagerTest.java
@@ -6,7 +6,7 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.pubnub.api.PubNub;
 import com.pubnub.api.PubNubException;
 import com.pubnub.api.PubNubUtil;
-import com.pubnub.api.callbacks.PNCallback;
+import com.pubnub.api.callbacks.PNResultCallback;
 import com.pubnub.api.callbacks.SubscribeCallback;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNHeartbeatNotificationOptions;
@@ -21,6 +21,7 @@ import com.pubnub.api.models.consumer.pubsub.message_actions.PNMessageActionResu
 import com.pubnub.api.models.consumer.pubsub.objects.PNMembershipResult;
 import com.pubnub.api.models.consumer.pubsub.objects.PNSpaceResult;
 import com.pubnub.api.models.consumer.pubsub.objects.PNUserResult;
+
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -1315,7 +1316,7 @@ public class SubscriptionManagerTest extends TestHarness {
         pubnub.subscribe().channels(Arrays.asList("ch1", "ch2")).channelGroups(Arrays.asList("cg1", "cg2")).execute();
         pubnub.setPresenceState().channels(Arrays.asList("ch1")).channelGroups(Arrays.asList("cg2"))
                 .state(Arrays.asList("p1", "p2"))
-                .async(new PNCallback<PNSetStateResult>() {
+                .async(new PNResultCallback<PNSetStateResult>() {
                     @Override
                     public void onResponse(PNSetStateResult result, @NotNull PNStatus status) {
                     }


### PR DESCRIPTION
This class only contains a single abstract method (SAM), there's no reason for it to be a class and not an interface.

Declaring it as an interface allows for cleaner syntax for both Kotlin (SAM conversion) and Java (lambda) call-sites.

*PNCallback left as a class to not break existing inheritors