### PR TITLE
Fixed broken download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/pubnub/java.svg?branch=master)](https://travis-ci.com/pubnub/java)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/164fd518c314417e896b3de494ab75df)](https://www.codacy.com/app/PubNub/java?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pubnub/java&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/164fd518c314417e896b3de494ab75df)](https://www.codacy.com/app/PubNub/java?utm_source=github.com&utm_medium=referral&utm_content=pubnub/java&utm_campaign=Badge_Coverage)
-[![Download](https://api.bintray.com/packages/bintray/jcenter/com.pubnub%3Apubnub-gson/images/download.svg)](https://bintray.com/bintray/jcenter/com.pubnub%3Apubnub-gson/_latestVersion)
+<a href="https://jfrog.com/distribution/?bintrayRD=1" target="blank">Download</a>
 [![Maven Central](https://img.shields.io/maven-central/v/com.pubnub/pubnub-gson.svg)]()
 
 This is the official PubNub Java SDK repository.


### PR DESCRIPTION
Download badge broken, instead of that added hyperlink
![Screenshot from 2021-08-31 21-29-23](https://user-images.githubusercontent.com/51878265/131536551-192003fa-3bad-4c86-bbe5-4ea5193e63b2.png)
