### PR TITLE
Make the UUID mandatory

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,9 @@
 name: java
-version: v5.3.0
+version: v6.0.0
 schema: 1
 scm: github.com/pubnub/java
 files:
-  - build/libs/pubnub-gson-5.3.0-all.jar
+  - build/libs/pubnub-gson-6.0.0-all.jar
 sdks:
   - 
       type: library
@@ -23,8 +23,8 @@ sdks:
             -
               distribution-type: library
               distribution-repository: GitHub
-              package-name: pubnub-gson-5.3.0
-              location: https://github.com/pubnub/java/releases/download/v5.3.0/pubnub-gson-5.3.0-all.jar
+              package-name: pubnub-gson-6.0.0
+              location: https://github.com/pubnub/java/releases/download/v6.0.0/pubnub-gson-6.0.0-all.jar
               supported-platforms:
                 supported-operating-systems:
                   Android:
@@ -135,8 +135,8 @@ sdks:
             -
               distribution-type: library
               distribution-repository: maven 
-              package-name: pubnub-gson-5.3.0
-              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-gson/5.3.0/pubnub-gson-5.3.0.jar
+              package-name: pubnub-gson-6.0.0
+              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-gson/6.0.0/pubnub-gson-6.0.0.jar
               supported-platforms:
                 supported-operating-systems:
                   Android:
@@ -234,6 +234,11 @@ sdks:
                   is-required: Required
 
 changelog:
+  - date: 2022-01-12
+    version: v6.0.0
+    changes:
+      - type: improvement
+        text: "BREAKING CHANGES: uuid is required parameter in PNConfiguration constructor."
   - date: 2021-12-16
     version: v5.3.0
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v6.0.0
+January 12 2022
+
+#### Modified
+- BREAKING CHANGES: uuid is required parameter in PNConfiguration constructor.
+
 ## v5.3.0
 December 16 2021
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
      <dependency>
        <groupId>com.pubnub</groupId>
        <artifactId>pubnub-gson</artifactId>
-       <version>5.3.0</version>
+       <version>6.0.0</version>
      </dependency>
      ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 group = 'com.pubnub'
 
-version = '5.3.0'
+version = '6.0.0'
 
 description = """"""
 

--- a/src/integrationTest/java/com/pubnub/api/integration/managers/subscription/AbstractReconnectionProblem.java
+++ b/src/integrationTest/java/com/pubnub/api/integration/managers/subscription/AbstractReconnectionProblem.java
@@ -181,7 +181,7 @@ public abstract class AbstractReconnectionProblem {
     protected abstract PubNub privilegedClientPubNub();
 
     private PubNub adminPubNub() {
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setSubscribeKey(itPamTestConfig.pamSubKey());
         pnConfiguration.setPublishKey(itPamTestConfig.pamPubKey());
         pnConfiguration.setSecretKey(itPamTestConfig.pamSecKey());

--- a/src/integrationTest/java/com/pubnub/api/integration/managers/subscription/ReconnectionProblemWithReconnectionPolicy.java
+++ b/src/integrationTest/java/com/pubnub/api/integration/managers/subscription/ReconnectionProblemWithReconnectionPolicy.java
@@ -10,7 +10,7 @@ import static com.pubnub.api.enums.PNReconnectionPolicy.LINEAR;
 public class ReconnectionProblemWithReconnectionPolicy extends AbstractReconnectionProblem {
     @Override
     protected PubNub privilegedClientPubNub() {
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setSubscribeKey(itPamTestConfig.pamSubKey());
         pnConfiguration.setPublishKey(itPamTestConfig.pamPubKey());
         pnConfiguration.setSubscribeTimeout(5);

--- a/src/integrationTest/java/com/pubnub/api/integration/managers/subscription/ReconnectionProblemWithoutReconnectionPolicy.java
+++ b/src/integrationTest/java/com/pubnub/api/integration/managers/subscription/ReconnectionProblemWithoutReconnectionPolicy.java
@@ -10,7 +10,7 @@ import static com.pubnub.api.enums.PNReconnectionPolicy.NONE;
 public class ReconnectionProblemWithoutReconnectionPolicy extends AbstractReconnectionProblem {
     @Override
     protected PubNub privilegedClientPubNub() {
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setSubscribeKey(itPamTestConfig.pamSubKey());
         pnConfiguration.setPublishKey(itPamTestConfig.pamPubKey());
         pnConfiguration.setSubscribeTimeout(SUBSCRIBE_TIMEOUT);

--- a/src/integrationTest/java/com/pubnub/api/integration/objects/ObjectsApiBaseIT.java
+++ b/src/integrationTest/java/com/pubnub/api/integration/objects/ObjectsApiBaseIT.java
@@ -18,7 +18,7 @@ public abstract class ObjectsApiBaseIT {
     protected final PubNub pubNubUnderTest = pubNub();
 
     private PubNub pubNub() {
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setSubscribeKey(itTestConfig.subscribeKey());
         pnConfiguration.setLogVerbosity(PNLogVerbosity.BODY);
 

--- a/src/integrationTest/java/com/pubnub/api/integration/util/BaseIntegrationTest.java
+++ b/src/integrationTest/java/com/pubnub/api/integration/util/BaseIntegrationTest.java
@@ -128,8 +128,8 @@ public abstract class BaseIntegrationTest {
         client.forceDestroy();
     }
 
-    protected PNConfiguration getBasicPnConfiguration() {
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+    protected PNConfiguration getBasicPnConfiguration() throws PubNubException {
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         if (!needsServer()) {
             pnConfiguration.setSubscribeKey(SUB_KEY);
             pnConfiguration.setPublishKey(PUB_KEY);
@@ -144,8 +144,8 @@ public abstract class BaseIntegrationTest {
         return pnConfiguration;
     }
 
-    private PNConfiguration getServerPnConfiguration() {
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+    private PNConfiguration getServerPnConfiguration() throws PubNubException {
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setSubscribeKey(PAM_SUB_KEY);
         pnConfiguration.setPublishKey(PAM_PUB_KEY);
         pnConfiguration.setSecretKey(PAM_SEC_KEY);

--- a/src/main/java/com/pubnub/api/PNConfiguration.java
+++ b/src/main/java/com/pubnub/api/PNConfiguration.java
@@ -98,7 +98,7 @@ public class PNConfiguration {
     private String authKey;
 
     public void setUuid(@NotNull String uuid) throws PubNubException {
-        PubNubUtil.requirePN(uuid != null && !uuid.isEmpty(), PNERROBJ_UUID_NULL_OR_EMPTY);
+        PubNubUtil.require(uuid != null && !uuid.isEmpty(), PNERROBJ_UUID_NULL_OR_EMPTY);
         this.uuid = uuid;
     }
 
@@ -220,7 +220,7 @@ public class PNConfiguration {
      * @param uuid
      */
     public PNConfiguration(@NotNull String uuid) throws PubNubException {
-        PubNubUtil.requirePN(uuid != null && !uuid.isEmpty(), PNERROBJ_UUID_NULL_OR_EMPTY);
+        PubNubUtil.require(uuid != null && !uuid.isEmpty(), PNERROBJ_UUID_NULL_OR_EMPTY);
         setPresenceTimeoutWithCustomInterval(PRESENCE_TIMEOUT, 0);
 
         this.uuid = uuid;

--- a/src/main/java/com/pubnub/api/PNConfiguration.java
+++ b/src/main/java/com/pubnub/api/PNConfiguration.java
@@ -21,7 +21,8 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
 import java.net.Proxy;
 import java.net.ProxySelector;
-import java.util.UUID;
+
+import static com.pubnub.api.builder.PubNubErrorBuilder.PNERROBJ_UUID_NULL_OR_EMPTY;
 
 @Getter
 @Setter
@@ -95,6 +96,12 @@ public class PNConfiguration {
     private String secretKey;
     private String cipherKey;
     private String authKey;
+
+    public void setUuid(@NotNull String uuid) throws PubNubException {
+        PubNubUtil.requirePN(uuid != null && !uuid.isEmpty(), PNERROBJ_UUID_NULL_OR_EMPTY);
+        this.uuid = uuid;
+    }
+
     private String uuid;
     /**
      * If proxies are forcefully caching requests, set to true to allow the client to randomize the subdomain.
@@ -206,14 +213,17 @@ public class PNConfiguration {
     @Deprecated
     @Setter
     private boolean managePresenceListManually;
+
     /**
      * Initialize the PNConfiguration with default values
+     *
+     * @param uuid
      */
-    public PNConfiguration() {
+    public PNConfiguration(@NotNull String uuid) throws PubNubException {
+        PubNubUtil.requirePN(uuid != null && !uuid.isEmpty(), PNERROBJ_UUID_NULL_OR_EMPTY);
         setPresenceTimeoutWithCustomInterval(PRESENCE_TIMEOUT, 0);
 
-        uuid = "pn-" + UUID.randomUUID().toString();
-
+        this.uuid = uuid;
         nonSubscribeRequestTimeout = NON_SUBSCRIBE_REQUEST_TIMEOUT;
         subscribeTimeout = SUBSCRIBE_TIMEOUT;
         connectTimeout = CONNECT_TIMEOUT;

--- a/src/main/java/com/pubnub/api/PNConfiguration.java
+++ b/src/main/java/com/pubnub/api/PNConfiguration.java
@@ -98,7 +98,7 @@ public class PNConfiguration {
     private String authKey;
 
     public void setUuid(@NotNull String uuid) throws PubNubException {
-        PubNubUtil.require(uuid != null && !uuid.isEmpty(), PNERROBJ_UUID_NULL_OR_EMPTY);
+        PubNubUtil.require(uuid != null && !uuid.trim().isEmpty(), PNERROBJ_UUID_NULL_OR_EMPTY);
         this.uuid = uuid;
     }
 

--- a/src/main/java/com/pubnub/api/PubNub.java
+++ b/src/main/java/com/pubnub/api/PubNub.java
@@ -137,6 +137,11 @@ public class PubNub {
     }
 
     @NotNull
+    public static String generateUUID() {
+        return "pn-" + UUID.randomUUID();
+    }
+
+    @NotNull
     public String getBaseUrl() {
         return this.basePathManager.getBasePath();
     }

--- a/src/main/java/com/pubnub/api/PubNub.java
+++ b/src/main/java/com/pubnub/api/PubNub.java
@@ -104,7 +104,7 @@ public class PubNub {
     private static final int TIMESTAMP_DIVIDER = 1000;
     private static final int MAX_SEQUENCE = 65535;
 
-    private static final String SDK_VERSION = "5.3.0";
+    private static final String SDK_VERSION = "6.0.0";
     private final ListenerManager listenerManager;
     private final StateManager stateManager;
 

--- a/src/main/java/com/pubnub/api/PubNubUtil.java
+++ b/src/main/java/com/pubnub/api/PubNubUtil.java
@@ -290,7 +290,7 @@ public class PubNubUtil {
         return collection == null || collection.isEmpty();
     }
 
-    public static void requirePN(boolean value, PubNubError error) throws PubNubException {
+    public static void require(boolean value, PubNubError error) throws PubNubException {
         if (!value) {
             throw PubNubException.builder().pubnubError(error).build();
         }

--- a/src/main/java/com/pubnub/api/PubNubUtil.java
+++ b/src/main/java/com/pubnub/api/PubNubUtil.java
@@ -290,4 +290,10 @@ public class PubNubUtil {
         return collection == null || collection.isEmpty();
     }
 
+    public static void requirePN(boolean value, PubNubError error) throws PubNubException {
+        if (!value) {
+            throw PubNubException.builder().pubnubError(error).build();
+        }
+    }
+
 }

--- a/src/main/java/com/pubnub/api/builder/PubNubErrorBuilder.java
+++ b/src/main/java/com/pubnub/api/builder/PubNubErrorBuilder.java
@@ -351,6 +351,11 @@ public final class PubNubErrorBuilder {
      */
     public static final int PNERR_TOKEN_MISSING = 168;
 
+    /**
+     * UUID can't be null nor empty
+     */
+    public static final int PNERR_UUID_NULL_OR_EMPTY = 169;
+
     // Error Objects
     public static final PubNubError PNERROBJ_TIMEOUT = PubNubError.builder()
             .errorCode(PNERR_TIMEOUT)
@@ -698,6 +703,11 @@ public final class PubNubErrorBuilder {
     public static final PubNubError PNERROBJ_TOKEN_MISSING = PubNubError.builder()
             .errorCode(PNERR_TOKEN_MISSING)
             .message("Token missing.")
+            .build();
+
+    public static final PubNubError PNERROBJ_UUID_NULL_OR_EMPTY = PubNubError.builder()
+            .errorCode(PNERR_UUID_NULL_OR_EMPTY)
+            .message("Uuid can't be null nor empty.")
             .build();
 
     private PubNubErrorBuilder() {

--- a/src/test/java/com/pubnub/api/PubNubExceptionTest.java
+++ b/src/test/java/com/pubnub/api/PubNubExceptionTest.java
@@ -22,7 +22,7 @@ public class PubNubExceptionTest extends TestHarness {
     private Publish instance;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         PubNub pubnub = this.createPubNubInstance();
         instance = pubnub.publish();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/PubNubTest.java
+++ b/src/test/java/com/pubnub/api/PubNubTest.java
@@ -99,7 +99,7 @@ public class PubNubTest {
         pubnub = new PubNub(pnConfiguration);
         String version = pubnub.getVersion();
         int timeStamp = pubnub.getTimestamp();
-        Assert.assertEquals("5.3.0", version);
+        Assert.assertEquals("6.0.0", version);
         Assert.assertTrue(timeStamp > 0);
     }
 

--- a/src/test/java/com/pubnub/api/PubNubTest.java
+++ b/src/test/java/com/pubnub/api/PubNubTest.java
@@ -13,8 +13,8 @@ public class PubNubTest {
     private PNConfiguration pnConfiguration;
 
     @Before
-    public void beforeEach() throws IOException {
-        pnConfiguration = new PNConfiguration();
+    public void beforeEach() throws IOException, PubNubException {
+        pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setSubscribeKey("demo");
         pnConfiguration.setPublishKey("demo");
         pnConfiguration.setUseRandomInitializationVector(false);

--- a/src/test/java/com/pubnub/api/endpoints/DeleteMessagesEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/DeleteMessagesEndpointTest.java
@@ -26,7 +26,7 @@ public class DeleteMessagesEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialHistory = pubnub.deleteMessages();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/EndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/EndpointTest.java
@@ -27,7 +27,7 @@ public class EndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         pubnub.getConfiguration().setIncludeInstanceIdentifier(true);
     }

--- a/src/test/java/com/pubnub/api/endpoints/FetchMessagesEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/FetchMessagesEndpointTest.java
@@ -25,7 +25,7 @@ public class FetchMessagesEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialHistory = pubnub.fetchMessages();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/HeartbeatEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/HeartbeatEndpointTest.java
@@ -35,7 +35,7 @@ public class HeartbeatEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         RetrofitManager retrofitManager = new RetrofitManager(pubnub);
         partialHeartbeat = new Heartbeat(pubnub, null, retrofitManager, new TokenManager());

--- a/src/test/java/com/pubnub/api/endpoints/HistoryBatchEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/HistoryBatchEndpointTest.java
@@ -55,6 +55,9 @@ public class HistoryBatchEndpointTest {
     private final TelemetryManager telemetryManager = mock(TelemetryManager.class);
     private final ArgumentCaptor<Map<String, String>> optionsCaptor = ArgumentCaptor.forClass(Map.class);
 
+    public HistoryBatchEndpointTest() throws PubNubException {
+    }
+
     @Test
     public void forSingleChannelFetchMessagesAlwaysPassMaxWhenItIsInBound() throws PubNubException {
         //given
@@ -335,8 +338,8 @@ public class HistoryBatchEndpointTest {
         return retrofitManager;
     }
 
-    private PubNub pubNubMock() {
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+    private PubNub pubNubMock() throws PubNubException {
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setSubscribeKey(SUBSCRIBE_KEY);
 
         final PubNub pubnub = mock(PubNub.class);

--- a/src/test/java/com/pubnub/api/endpoints/HistoryEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/HistoryEndpointTest.java
@@ -45,7 +45,7 @@ public class HistoryEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialHistory = pubnub.history();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/MessageCountTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/MessageCountTest.java
@@ -34,7 +34,7 @@ public class MessageCountTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         wireMockRule.start();
     }

--- a/src/test/java/com/pubnub/api/endpoints/TestHarness.java
+++ b/src/test/java/com/pubnub/api/endpoints/TestHarness.java
@@ -2,13 +2,14 @@ package com.pubnub.api.endpoints;
 
 import com.pubnub.api.PNConfiguration;
 import com.pubnub.api.PubNub;
+import com.pubnub.api.PubNubException;
 import com.pubnub.api.enums.PNLogVerbosity;
 
 public class TestHarness {
     protected final static int PORT = 8080;
 
-    protected PubNub createPubNubInstance() {
-        PNConfiguration pnConfiguration = new PNConfiguration();
+    protected PubNub createPubNubInstance() throws PubNubException {
+        PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setOrigin("localhost" + ":" + PORT);
         pnConfiguration.setSecure(false);
         pnConfiguration.setSubscribeKey("mySubscribeKey");

--- a/src/test/java/com/pubnub/api/endpoints/TimeEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/TimeEndpointTest.java
@@ -39,7 +39,7 @@ public class TimeEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialTime = pubnub.time();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/access/GrantEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/access/GrantEndpointTest.java
@@ -46,7 +46,7 @@ public class GrantEndpointTest extends TestHarness {
     private String uuid = "myUUID";
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialGrant = pubnub.grant();
         pubnub.getConfiguration().setSecretKey("secretKey").setIncludeInstanceIdentifier(true);

--- a/src/test/java/com/pubnub/api/endpoints/access/GrantTokenEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/access/GrantTokenEndpointTest.java
@@ -24,6 +24,9 @@ public class GrantTokenEndpointTest extends TestHarness {
 
     private final PubNub pubnub = this.createPubNubInstance();
 
+    public GrantTokenEndpointTest() throws PubNubException {
+    }
+
     @Before
     public void beforeEach() throws IOException {
         pubnub.getConfiguration().setSecretKey("secretKey").setIncludeInstanceIdentifier(true);
@@ -66,7 +69,7 @@ public class GrantTokenEndpointTest extends TestHarness {
     @Test
     public void validate_SubscribeKeyMissing() {
         try {
-            new PubNub(new PNConfiguration().setSecretKey("secret")).grantToken()
+            new PubNub(new PNConfiguration(PubNub.generateUUID()).setSecretKey("secret")).grantToken()
                     .ttl(1)
                     .channelGroups(Collections.singletonList(ChannelGroupGrant.id("test").read()))
                     .sync();

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/AddChannelChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/AddChannelChannelGroupEndpointTest.java
@@ -36,7 +36,7 @@ public class AddChannelChannelGroupEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialAddChannelChannelGroup = pubnub.addChannelsToChannelGroup();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/AllChannelsChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/AllChannelsChannelGroupEndpointTest.java
@@ -41,7 +41,7 @@ public class AllChannelsChannelGroupEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialAllChannelsChannelGroup = pubnub.listChannelsForChannelGroup();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/DeleteChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/DeleteChannelGroupEndpointTest.java
@@ -35,7 +35,7 @@ public class DeleteChannelGroupEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialDeleteChannelGroup = pubnub.deleteChannelGroup();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/ListAllChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/ListAllChannelGroupEndpointTest.java
@@ -35,7 +35,7 @@ public class ListAllChannelGroupEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialChannelGroup = pubnub.listAllChannelGroups();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/channel_groups/RemoveChannelChannelGroupEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/channel_groups/RemoveChannelChannelGroupEndpointTest.java
@@ -36,7 +36,7 @@ public class RemoveChannelChannelGroupEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialRemoveChannelChannelGroup = pubnub.removeChannelsFromChannelGroup();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/files/GetFileUrlTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/files/GetFileUrlTest.java
@@ -95,8 +95,8 @@ public class GetFileUrlTest {
         Assert.assertThat(queryParamNames, Matchers.containsInAnyOrder("auth", "signature", "timestamp"));
     }
 
-    private PNConfiguration config() {
-        PNConfiguration config = new PNConfiguration();
+    private PNConfiguration config() throws PubNubException {
+        PNConfiguration config = new PNConfiguration(PubNub.generateUUID());
         config.setPublishKey("pk");
         config.setSubscribeKey("sk");
         return config;

--- a/src/test/java/com/pubnub/api/endpoints/presence/GetStateEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/presence/GetStateEndpointTest.java
@@ -44,7 +44,7 @@ public class GetStateEndpointTest extends TestHarness {
     private GetState partialGetState;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialGetState = pubnub.getPresenceState();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/presence/HereNowEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/presence/HereNowEndpointTest.java
@@ -42,7 +42,7 @@ public class HereNowEndpointTest extends TestHarness {
     private HereNow partialHereNow;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialHereNow = pubnub.hereNow();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/presence/LeaveTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/presence/LeaveTest.java
@@ -36,7 +36,7 @@ public class LeaveTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         RetrofitManager retrofitManager = new RetrofitManager(pubnub);
         instance = new Leave(pubnub, null, retrofitManager, new TokenManager());

--- a/src/test/java/com/pubnub/api/endpoints/presence/SetStateEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/presence/SetStateEndpointTest.java
@@ -40,7 +40,7 @@ public class SetStateEndpointTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialSetState = pubnub.setPresenceState();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/presence/WhereNowEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/presence/WhereNowEndpointTest.java
@@ -42,7 +42,7 @@ public class WhereNowEndpointTest extends TestHarness {
     private WhereNow partialWhereNow;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         partialWhereNow = pubnub.whereNow();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/pubsub/PublishTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/pubsub/PublishTest.java
@@ -41,7 +41,7 @@ public class PublishTest extends TestHarness {
     private Publish instance;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         instance = pubnub.publish();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/pubsub/SignalTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/pubsub/SignalTest.java
@@ -57,7 +57,7 @@ public class SignalTest extends TestHarness {
     private PubNub pubNub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubNub = this.createPubNubInstance();
         wireMockRule.start();
     }

--- a/src/test/java/com/pubnub/api/endpoints/pubsub/SubscribeEndpointTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/pubsub/SubscribeEndpointTest.java
@@ -41,7 +41,7 @@ public class SubscribeEndpointTest extends TestHarness {
     private Subscribe instance;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         RetrofitManager retrofitManager = new RetrofitManager(pubnub);
         instance = new Subscribe(pubnub, retrofitManager, new TokenManager());

--- a/src/test/java/com/pubnub/api/endpoints/push/ListPushProvisionsTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/push/ListPushProvisionsTest.java
@@ -44,7 +44,7 @@ public class ListPushProvisionsTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         instance = pubnub.auditPushChannelProvisions();
         wireMockRule.start();

--- a/src/test/java/com/pubnub/api/endpoints/push/ModifyPushChannelsForDeviceTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/push/ModifyPushChannelsForDeviceTest.java
@@ -55,7 +55,7 @@ public class ModifyPushChannelsForDeviceTest extends TestHarness {
     private RemoveChannelsFromPush instanceRemove;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         instance = pubnub.removeAllPushNotificationsFromDeviceWithPushToken();
         instanceAdd = pubnub.addPushNotificationsOnChannels();

--- a/src/test/java/com/pubnub/api/endpoints/push/PushPayloadHelperHelperTest.java
+++ b/src/test/java/com/pubnub/api/endpoints/push/PushPayloadHelperHelperTest.java
@@ -1,6 +1,7 @@
 package com.pubnub.api.endpoints.push;
 
 import com.pubnub.api.PubNub;
+import com.pubnub.api.PubNubException;
 import com.pubnub.api.endpoints.TestHarness;
 import com.pubnub.api.enums.PNPushEnvironment;
 import com.pubnub.api.models.consumer.push.payload.PushPayloadHelper;
@@ -21,7 +22,7 @@ public class PushPayloadHelperHelperTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
     }
 

--- a/src/test/java/com/pubnub/api/managers/BasePathManagerTest.java
+++ b/src/test/java/com/pubnub/api/managers/BasePathManagerTest.java
@@ -1,6 +1,8 @@
 package com.pubnub.api.managers;
 
 import com.pubnub.api.PNConfiguration;
+import com.pubnub.api.PubNub;
+import com.pubnub.api.PubNubException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,8 +14,8 @@ public class BasePathManagerTest {
     private PNConfiguration pnConfiguration;
 
     @Before
-    public void beforeEach() throws IOException {
-        pnConfiguration = new PNConfiguration();
+    public void beforeEach() throws IOException, PubNubException {
+        pnConfiguration = new PNConfiguration(PubNub.generateUUID());
     }
 
     @Test

--- a/src/test/java/com/pubnub/api/managers/ReconnectionManagerTest.java
+++ b/src/test/java/com/pubnub/api/managers/ReconnectionManagerTest.java
@@ -2,6 +2,7 @@ package com.pubnub.api.managers;
 
 import com.pubnub.api.PNConfiguration;
 import com.pubnub.api.PubNub;
+import com.pubnub.api.PubNubException;
 import com.pubnub.api.enums.PNReconnectionPolicy;
 import org.junit.Test;
 
@@ -10,8 +11,8 @@ import static org.junit.Assert.assertTrue;
 
 public class ReconnectionManagerTest {
     @Test
-    public void reconnectionIntervalsEqualsForLinear() {
-        PNConfiguration pnConfiguration = new PNConfiguration();
+    public void reconnectionIntervalsEqualsForLinear() throws PubNubException {
+        PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         PubNub pubNub = new PubNub(pnConfiguration);
         pnConfiguration.setReconnectionPolicy(PNReconnectionPolicy.LINEAR);
         final ReconnectionManager reconnectionManagerUnderTest = new ReconnectionManager(pubNub);
@@ -23,8 +24,8 @@ public class ReconnectionManagerTest {
     }
 
     @Test
-    public void reconnectionIntervalsIncreaseForExponential() {
-        PNConfiguration pnConfiguration = new PNConfiguration();
+    public void reconnectionIntervalsIncreaseForExponential() throws PubNubException {
+        PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setReconnectionPolicy(PNReconnectionPolicy.EXPONENTIAL);
         PubNub pubNub = new PubNub(pnConfiguration);
         final ReconnectionManager reconnectionManagerUnderTest = new ReconnectionManager(pubNub);

--- a/src/test/java/com/pubnub/api/managers/StateManagerTest.java
+++ b/src/test/java/com/pubnub/api/managers/StateManagerTest.java
@@ -1,6 +1,8 @@
 package com.pubnub.api.managers;
 
 import com.pubnub.api.PNConfiguration;
+import com.pubnub.api.PubNub;
+import com.pubnub.api.PubNubException;
 import com.pubnub.api.builder.dto.PresenceOperation;
 import com.pubnub.api.builder.dto.PubSubOperation;
 import com.pubnub.api.builder.dto.StateOperation;
@@ -27,9 +29,9 @@ public class StateManagerTest {
     final private String state = "state";
 
     @Test
-    public void heartbeatSendsAllChannelsWhenManualModeTurnedOff() {
+    public void heartbeatSendsAllChannelsWhenManualModeTurnedOff() throws PubNubException {
         //given
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         final StateManager stateManagerUnderTest = new StateManager(pnConfiguration);
 
         //when
@@ -53,9 +55,9 @@ public class StateManagerTest {
     }
 
     @Test
-    public void heartbeatSendsOnlyPresenceChannelsWhenManualModeTurnedOn() {
+    public void heartbeatSendsOnlyPresenceChannelsWhenManualModeTurnedOn() throws PubNubException {
         //given
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setManagePresenceListManually(true);
         final StateManager stateManagerUnderTest = new StateManager(pnConfiguration);
 
@@ -82,7 +84,7 @@ public class StateManagerTest {
     }
 
     @Test
-    public void whenManualModeStateOperationAddStateToSubscribedChannels() {
+    public void whenManualModeStateOperationAddStateToSubscribedChannels() throws PubNubException {
         //given
         StateManager stateManagerUnderTest = new StateManager(withManualPresenceMode(config()));
 
@@ -99,7 +101,7 @@ public class StateManagerTest {
     }
 
     @Test
-    public void whenManualModeStateOperationAddStateToHeartbeatChannels() {
+    public void whenManualModeStateOperationAddStateToHeartbeatChannels() throws PubNubException {
         //given
         StateManager stateManagerUnderTest = new StateManager(withManualPresenceMode(config()));
 
@@ -116,7 +118,7 @@ public class StateManagerTest {
     }
 
     @Test
-    public void whenManualModeOffStateOperationDoNotAddStateToHeartbeatChannels() {
+    public void whenManualModeOffStateOperationDoNotAddStateToHeartbeatChannels() throws PubNubException {
         //given
         StateManager stateManagerUnderTest = new StateManager(withoutManualPresenceMode(config()));
 
@@ -132,7 +134,7 @@ public class StateManagerTest {
     }
 
     @Test
-    public void whenManualModeOffStateOperationAddStateToSubscribedChannels() {
+    public void whenManualModeOffStateOperationAddStateToSubscribedChannels() throws PubNubException {
         //given
         StateManager stateManagerUnderTest = new StateManager(withoutManualPresenceMode(config()));
 
@@ -149,7 +151,7 @@ public class StateManagerTest {
     }
 
     @Test
-    public void whenManualModeStateOperationAddStateToSubscribedAndHeartbeatIfBothPresent() {
+    public void whenManualModeStateOperationAddStateToSubscribedAndHeartbeatIfBothPresent() throws PubNubException {
         //given
         StateManager stateManagerUnderTest = new StateManager(withManualPresenceMode(config()));
 
@@ -175,8 +177,8 @@ public class StateManagerTest {
         return result;
     }
 
-    private PNConfiguration config() {
-        return new PNConfiguration();
+    private PNConfiguration config() throws PubNubException {
+        return new PNConfiguration(PubNub.generateUUID());
     }
 
     private PNConfiguration withManualPresenceMode(PNConfiguration config) {

--- a/src/test/java/com/pubnub/api/managers/SubscriptionManagerTest.java
+++ b/src/test/java/com/pubnub/api/managers/SubscriptionManagerTest.java
@@ -65,7 +65,7 @@ public class SubscriptionManagerTest extends TestHarness {
     private PubNub pubnub;
 
     @Before
-    public void beforeEach() throws IOException {
+    public void beforeEach() throws IOException, PubNubException {
         pubnub = this.createPubNubInstance();
         wireMockRule.start();
     }

--- a/src/test/java/com/pubnub/api/managers/subscription/utils/SubscriptionTestUtils.java
+++ b/src/test/java/com/pubnub/api/managers/subscription/utils/SubscriptionTestUtils.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 public class SubscriptionTestUtils {
     @SneakyThrows
     public static PubNub pubnub(final RetrofitManager retrofitManager) {
-        final PNConfiguration pnConfiguration = new PNConfiguration();
+        final PNConfiguration pnConfiguration = new PNConfiguration(PubNub.generateUUID());
         pnConfiguration.setSubscribeKey("fake_sub_key");
         pnConfiguration.setConnectTimeout(1);
 

--- a/src/test/java/com/pubnub/api/workers/SubscribeMessageWorkerTest.java
+++ b/src/test/java/com/pubnub/api/workers/SubscribeMessageWorkerTest.java
@@ -3,6 +3,7 @@ package com.pubnub.api.workers;
 import com.google.gson.Gson;
 import com.pubnub.api.PNConfiguration;
 import com.pubnub.api.PubNub;
+import com.pubnub.api.PubNubException;
 import com.pubnub.api.PubNubUtil;
 import com.pubnub.api.callbacks.SubscribeCallback;
 import com.pubnub.api.managers.DuplicationManager;
@@ -35,7 +36,7 @@ public class SubscribeMessageWorkerTest {
     private final String authKey = "ak";
 
     @Test
-    public void fileEventUrlContainsAuthQueryParamWhenAuthIsSet() throws InterruptedException {
+    public void fileEventUrlContainsAuthQueryParamWhenAuthIsSet() throws InterruptedException, PubNubException {
         //given
         PNConfiguration config = configWithAuth(config());
         PubNub pubnub = new PubNub(config);
@@ -63,7 +64,7 @@ public class SubscribeMessageWorkerTest {
     }
 
     @Test
-    public void fileEventUrlContainsNoQueryParamsWhenNoSecretNorAuth() throws InterruptedException {
+    public void fileEventUrlContainsNoQueryParamsWhenNoSecretNorAuth() throws InterruptedException, PubNubException {
         //given
         PNConfiguration config = config();
         PubNub pubnub = new PubNub(config);
@@ -91,7 +92,7 @@ public class SubscribeMessageWorkerTest {
     }
 
     @Test
-    public void fileEventUrlContainsSignatureQueryParamWhenSecretIsSet() throws InterruptedException {
+    public void fileEventUrlContainsSignatureQueryParamWhenSecretIsSet() throws InterruptedException, PubNubException {
         //given
         PNConfiguration config = configWithSecret(config());
         PubNub pubnub = new PubNub(config);
@@ -118,7 +119,7 @@ public class SubscribeMessageWorkerTest {
     }
 
     @Test
-    public void fileEventUrlContainsSignatureAndAuthQueryParamsWhenAuthAndSecretAreSet() throws InterruptedException {
+    public void fileEventUrlContainsSignatureAndAuthQueryParamsWhenAuthAndSecretAreSet() throws InterruptedException, PubNubException {
         //given
         PNConfiguration config = configWithAuth(configWithSecret(config()));
         PubNub pubnub = new PubNub(config);
@@ -172,8 +173,8 @@ public class SubscribeMessageWorkerTest {
         );
     }
 
-    private PNConfiguration config() {
-        PNConfiguration config = new PNConfiguration();
+    private PNConfiguration config() throws PubNubException {
+        PNConfiguration config = new PNConfiguration(PubNub.generateUUID());
         config.setPublishKey("pk");
         config.setSubscribeKey("ck");
         return config;

--- a/src/test/java/com/pubnub/contract/Hooks.kt
+++ b/src/test/java/com/pubnub/contract/Hooks.kt
@@ -1,21 +1,36 @@
 package com.pubnub.contract
 
+import com.pubnub.api.PNConfiguration
+import com.pubnub.api.PubNub
+import com.pubnub.api.callbacks.SubscribeCallback
+import com.pubnub.api.enums.PNLogVerbosity
+import com.pubnub.api.models.consumer.PNStatus
+import com.pubnub.api.models.consumer.access_manager.v3.ChannelGrant
+import com.pubnub.api.models.consumer.objects_api.channel.PNChannelMetadataResult
+import com.pubnub.api.models.consumer.objects_api.membership.PNMembershipResult
+import com.pubnub.api.models.consumer.objects_api.uuid.PNUUIDMetadataResult
+import com.pubnub.api.models.consumer.pubsub.PNMessageResult
+import com.pubnub.api.models.consumer.pubsub.PNPresenceEventResult
+import com.pubnub.api.models.consumer.pubsub.PNSignalResult
+import com.pubnub.api.models.consumer.pubsub.files.PNFileEventResult
+import com.pubnub.api.models.consumer.pubsub.message_actions.PNMessageActionResult
 import io.cucumber.java.After
 import io.cucumber.java.Before
 import io.cucumber.java.Scenario
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.junit.Assert.fail
+import org.junit.Test
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 class Hooks {
     private val interceptor = HttpLoggingInterceptor();
     private val mockPubnubService: MockPubnubService = Retrofit.Builder()
-        .client(OkHttpClient.Builder().addInterceptor(interceptor).build())
-        .baseUrl("http://" + CONTRACT_TEST_CONFIG.serverHostPort())
-        .addConverterFactory(GsonConverterFactory.create())
-        .build().create(MockPubnubService::class.java)
+            .client(OkHttpClient.Builder().addInterceptor(interceptor).build())
+            .baseUrl("http://" + CONTRACT_TEST_CONFIG.serverHostPort())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build().create(MockPubnubService::class.java)
 
     @Before
     fun before(scenario: Scenario) {
@@ -38,10 +53,10 @@ class Hooks {
                 fail("Expect response body is null")
             } else {
                 if (responseBody.expectations.pending.isNotEmpty() ||
-                    responseBody.expectations.failed.isNotEmpty()) {
+                        responseBody.expectations.failed.isNotEmpty()) {
                     fail("""Scenario ${responseBody.contract} considered failure: 
-                            pending - ${responseBody.expectations.pending.joinToString() },
-                            failed - ${responseBody.expectations.failed.joinToString() }""".trimIndent())
+                            pending - ${responseBody.expectations.pending.joinToString()},
+                            failed - ${responseBody.expectations.failed.joinToString()}""".trimIndent())
                 }
             }
 
@@ -50,10 +65,10 @@ class Hooks {
 
     private fun Scenario.contractName(): String? {
         return sourceTagNames
-            .filter { it: String -> it.startsWith("@contract") }
-            .map { it: String ->
-                it.split("=").toTypedArray()[1]
-            }
-            .firstOrNull()
+                .filter { it: String -> it.startsWith("@contract") }
+                .map { it: String ->
+                    it.split("=").toTypedArray()[1]
+                }
+                .firstOrNull()
     }
 }

--- a/src/test/java/com/pubnub/contract/MockPubnubService.kt
+++ b/src/test/java/com/pubnub/contract/MockPubnubService.kt
@@ -1,5 +1,20 @@
 package com.pubnub.contract
 
+import com.pubnub.api.PNConfiguration
+import com.pubnub.api.PubNub
+import com.pubnub.api.callbacks.SubscribeCallback
+import com.pubnub.api.enums.PNLogVerbosity
+import com.pubnub.api.models.consumer.PNStatus
+import com.pubnub.api.models.consumer.access_manager.v3.ChannelGrant
+import com.pubnub.api.models.consumer.objects_api.channel.PNChannelMetadataResult
+import com.pubnub.api.models.consumer.objects_api.membership.PNMembershipResult
+import com.pubnub.api.models.consumer.objects_api.uuid.PNUUIDMetadataResult
+import com.pubnub.api.models.consumer.pubsub.PNMessageResult
+import com.pubnub.api.models.consumer.pubsub.PNPresenceEventResult
+import com.pubnub.api.models.consumer.pubsub.PNSignalResult
+import com.pubnub.api.models.consumer.pubsub.files.PNFileEventResult
+import com.pubnub.api.models.consumer.pubsub.message_actions.PNMessageActionResult
+import org.junit.Test
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.QueryMap
@@ -13,6 +28,10 @@ interface MockPubnubService {
 
     @GET("expect")
     fun expect(): Call<ExpectResponse>
+}
+
+class A {
+
 }
 
 data class ExpectResponse(

--- a/src/test/java/com/pubnub/contract/MockPubnubService.kt
+++ b/src/test/java/com/pubnub/contract/MockPubnubService.kt
@@ -1,20 +1,5 @@
 package com.pubnub.contract
 
-import com.pubnub.api.PNConfiguration
-import com.pubnub.api.PubNub
-import com.pubnub.api.callbacks.SubscribeCallback
-import com.pubnub.api.enums.PNLogVerbosity
-import com.pubnub.api.models.consumer.PNStatus
-import com.pubnub.api.models.consumer.access_manager.v3.ChannelGrant
-import com.pubnub.api.models.consumer.objects_api.channel.PNChannelMetadataResult
-import com.pubnub.api.models.consumer.objects_api.membership.PNMembershipResult
-import com.pubnub.api.models.consumer.objects_api.uuid.PNUUIDMetadataResult
-import com.pubnub.api.models.consumer.pubsub.PNMessageResult
-import com.pubnub.api.models.consumer.pubsub.PNPresenceEventResult
-import com.pubnub.api.models.consumer.pubsub.PNSignalResult
-import com.pubnub.api.models.consumer.pubsub.files.PNFileEventResult
-import com.pubnub.api.models.consumer.pubsub.message_actions.PNMessageActionResult
-import org.junit.Test
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.QueryMap
@@ -28,10 +13,6 @@ interface MockPubnubService {
 
     @GET("expect")
     fun expect(): Call<ExpectResponse>
-}
-
-class A {
-
 }
 
 data class ExpectResponse(

--- a/src/test/java/com/pubnub/contract/RunMainCucumberTest.kt
+++ b/src/test/java/com/pubnub/contract/RunMainCucumberTest.kt
@@ -13,7 +13,8 @@ class RunMainCucumberTest
 
 @RunWith(Cucumber::class)
 @CucumberOptions(
-        tags = "not @skip and not @na=ruby and @beta",
+        features = ["../service-contract-mock/contract/features/access"],
+        //tags = "not @skip and not @na=ruby and @beta",
         plugin = ["pretty", "summary", "junit:build/reports/cucumber-reports/beta.xml"]
 )
 class RunBetaCucumberTest

--- a/src/test/java/com/pubnub/contract/state/World.kt
+++ b/src/test/java/com/pubnub/contract/state/World.kt
@@ -7,7 +7,7 @@ import com.pubnub.api.PubNubException
 import com.pubnub.api.enums.PNLogVerbosity
 
 class World {
-    val configuration: PNConfiguration by lazy { PNConfiguration().apply {
+    val configuration: PNConfiguration by lazy { PNConfiguration(PubNub.generateUUID()).apply {
         origin = CONTRACT_TEST_CONFIG.serverHostPort()
         isSecure = false
         logVerbosity = PNLogVerbosity.BODY


### PR DESCRIPTION
refactor: Breaking change, uuid parameter is mandatory.

uuid is required parameter in PNConfiguration constructor.

BREAKING CHANGES: SDK will not generate or store uuid automatically. uuid is required parameter in PNConfiguration constructor.