### PR TITLE
Do heartbeat and leave calls in sequence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'org.jetbrains:annotations:17.0.0'
 
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testImplementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.3'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
     testImplementation group: 'junit', name: 'junit', version: '4.12'

--- a/config/findbugs/excludeFilter.xml
+++ b/config/findbugs/excludeFilter.xml
@@ -65,4 +65,9 @@
         <Field name="updated"/>
         <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
     </Match>
+    <Match>
+        <Class name="com.pubnub.api.PubNubException"/>
+        <Field name="affectedCall"/>
+        <Bug pattern="URF_UNREAD_FIELD"/>
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/com/pubnub/api/endpoints/presence/GetState.java
+++ b/src/main/java/com/pubnub/api/endpoints/presence/GetState.java
@@ -69,7 +69,7 @@ public class GetState extends Endpoint<Envelope<JsonElement>, PNGetStateResult> 
 
         String selectedUUID = uuid != null ? uuid : this.getPubnub().getConfiguration().getUuid();
 
-        return this.getRetrofit().getPresenceService().getState(
+        return this.getRetrofit().getExtendedPresenceService().getState(
                 this.getPubnub().getConfiguration().getSubscribeKey(), channelCSV, selectedUUID, params);
     }
 

--- a/src/main/java/com/pubnub/api/endpoints/presence/HereNow.java
+++ b/src/main/java/com/pubnub/api/endpoints/presence/HereNow.java
@@ -91,9 +91,9 @@ public class HereNow extends Endpoint<Envelope<JsonElement>, PNHereNowResult> {
         }
 
         if (channels.size() > 0 || channelGroups.size() > 0) {
-            return this.getRetrofit().getPresenceService().hereNow(this.getPubnub().getConfiguration().getSubscribeKey(), channelCSV, params);
+            return this.getRetrofit().getExtendedPresenceService().hereNow(this.getPubnub().getConfiguration().getSubscribeKey(), channelCSV, params);
         } else {
-            return this.getRetrofit().getPresenceService().globalHereNow(this.getPubnub().getConfiguration().getSubscribeKey(), params);
+            return this.getRetrofit().getExtendedPresenceService().globalHereNow(this.getPubnub().getConfiguration().getSubscribeKey(), params);
         }
     }
 

--- a/src/main/java/com/pubnub/api/endpoints/presence/SetState.java
+++ b/src/main/java/com/pubnub/api/endpoints/presence/SetState.java
@@ -104,7 +104,7 @@ public class SetState extends Endpoint<Envelope<JsonElement>, PNSetStateResult> 
 
         String channelCSV = channels.size() > 0 ? PubNubUtil.joinString(channels, ",") : ",";
 
-        return this.getRetrofit().getPresenceService().setState(
+        return this.getRetrofit().getExtendedPresenceService().setState(
                 this.getPubnub().getConfiguration().getSubscribeKey(), channelCSV, selectedUUID, params);
     }
 

--- a/src/main/java/com/pubnub/api/endpoints/presence/WhereNow.java
+++ b/src/main/java/com/pubnub/api/endpoints/presence/WhereNow.java
@@ -51,7 +51,7 @@ public class WhereNow extends Endpoint<Envelope<WhereNowPayload>, PNWhereNowResu
 
     @Override
     protected Call<Envelope<WhereNowPayload>> doWork(Map<String, String> params) {
-        return this.getRetrofit().getPresenceService().whereNow(this.getPubnub().getConfiguration().getSubscribeKey(),
+        return this.getRetrofit().getExtendedPresenceService().whereNow(this.getPubnub().getConfiguration().getSubscribeKey(),
                 this.uuid != null ? this.uuid : this.getPubnub().getConfiguration().getUuid(), params);
     }
 
@@ -77,5 +77,4 @@ public class WhereNow extends Endpoint<Envelope<WhereNowPayload>, PNWhereNowResu
     protected boolean isAuthRequired() {
         return true;
     }
-
 }

--- a/src/main/java/com/pubnub/api/managers/RetrofitManager.java
+++ b/src/main/java/com/pubnub/api/managers/RetrofitManager.java
@@ -8,21 +8,9 @@ import com.pubnub.api.enums.PNLogVerbosity;
 import com.pubnub.api.enums.PNStatusCategory;
 import com.pubnub.api.interceptors.SignatureInterceptor;
 import com.pubnub.api.models.consumer.PNStatus;
-import com.pubnub.api.services.AccessManagerService;
-import com.pubnub.api.services.ChannelGroupService;
-import com.pubnub.api.services.ChannelMetadataService;
-import com.pubnub.api.services.FilesService;
-import com.pubnub.api.services.HistoryService;
-import com.pubnub.api.services.MessageActionService;
-import com.pubnub.api.services.PresenceService;
-import com.pubnub.api.services.PublishService;
-import com.pubnub.api.services.PushService;
-import com.pubnub.api.services.S3Service;
-import com.pubnub.api.services.SignalService;
-import com.pubnub.api.services.SubscribeService;
-import com.pubnub.api.services.TimeService;
-import com.pubnub.api.services.UUIDMetadataService;
+import com.pubnub.api.services.*;
 import lombok.Getter;
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.jetbrains.annotations.NotNull;
@@ -35,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 
 public class RetrofitManager {
 
+
+
     private PubNub pubnub;
 
     private SignatureInterceptor signatureInterceptor;
@@ -42,6 +32,7 @@ public class RetrofitManager {
     private OkHttpClient transactionClientInstance;
     private OkHttpClient subscriptionClientInstance;
     private OkHttpClient noSignatureClientInstance;
+    private OkHttpClient presenceClientInstance;
 
 
     // services
@@ -71,15 +62,18 @@ public class RetrofitManager {
     private MessageActionService messageActionService;
     @Getter
     private final FilesService filesService;
-
     @Getter
     private final S3Service s3Service;
+    @Getter
+    private final ExtendedPresenceService extendedPresenceService;
     @Getter
     private final Retrofit transactionInstance;
     @Getter
     private final Retrofit subscriptionInstance;
     @Getter
     private final Retrofit noSignatureInstance;
+    @Getter
+    private final Retrofit presenceInstance;
 
     public RetrofitManager(PubNub pubNubInstance) {
         this.pubnub = pubNubInstance;
@@ -87,12 +81,26 @@ public class RetrofitManager {
         this.signatureInterceptor = new SignatureInterceptor(pubNubInstance);
 
         if (!pubNubInstance.getConfiguration().isGoogleAppEngineNetworking()) {
+
+
             this.transactionClientInstance = createOkHttpClient(
                     prepareOkHttpClient(
                             this.pubnub.getConfiguration().getNonSubscribeRequestTimeout(),
                             this.pubnub.getConfiguration().getConnectTimeout()
                     ).addInterceptor(this.signatureInterceptor)
-                    .retryOnConnectionFailure(false)
+                            .retryOnConnectionFailure(false)
+            );
+
+            Dispatcher dispatcher = new Dispatcher();
+            dispatcher.setMaxRequestsPerHost(1);
+
+            this.presenceClientInstance = createOkHttpClient(
+                    prepareOkHttpClient(
+                            this.pubnub.getConfiguration().getNonSubscribeRequestTimeout(),
+                            this.pubnub.getConfiguration().getConnectTimeout()
+                    ).addInterceptor(this.signatureInterceptor)
+                            .retryOnConnectionFailure(false)
+                            .dispatcher(dispatcher)
             );
 
             this.subscriptionClientInstance = createOkHttpClient(
@@ -100,7 +108,7 @@ public class RetrofitManager {
                             this.pubnub.getConfiguration().getSubscribeTimeout(),
                             this.pubnub.getConfiguration().getConnectTimeout()
                     ).addInterceptor(this.signatureInterceptor)
-                    .retryOnConnectionFailure(false)
+                            .retryOnConnectionFailure(false)
             );
 
             this.noSignatureClientInstance = createOkHttpClient(
@@ -131,8 +139,9 @@ public class RetrofitManager {
         this.transactionInstance = createRetrofit(this.transactionClientInstance);
         this.subscriptionInstance = createRetrofit(this.subscriptionClientInstance);
         this.noSignatureInstance = createRetrofit(this.noSignatureClientInstance);
+        this.presenceInstance = createRetrofit(this.presenceClientInstance);
 
-        this.presenceService = transactionInstance.create(PresenceService.class);
+        this.presenceService = presenceInstance.create(PresenceService.class);
         this.historyService = transactionInstance.create(HistoryService.class);
         this.pushService = transactionInstance.create(PushService.class);
         this.accessManagerService = transactionInstance.create(AccessManagerService.class);
@@ -146,6 +155,8 @@ public class RetrofitManager {
         this.messageActionService = transactionInstance.create(MessageActionService.class);
         this.filesService = transactionInstance.create(FilesService.class);
         this.s3Service = noSignatureInstance.create(S3Service.class);
+        this.extendedPresenceService = transactionInstance.create(ExtendedPresenceService.class);
+
     }
 
     private OkHttpClient.Builder prepareOkHttpClient(int requestTimeout, int connectTimeOut) {

--- a/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
+++ b/src/main/java/com/pubnub/api/managers/SubscriptionManager.java
@@ -189,6 +189,8 @@ public class SubscriptionManager {
     }
 
     public void adaptUnsubscribeBuilder(UnsubscribeOperation unsubscribeOperation) {
+        reconnect(unsubscribeOperation);
+
         if (!this.pubnub.getConfiguration().isSuppressLeaveEvents()) {
             new Leave(pubnub, this.telemetryManager, this.retrofitManager, tokenManager)
                     .channels(unsubscribeOperation.getChannels())
@@ -205,8 +207,6 @@ public class SubscriptionManager {
                         }
                     });
         }
-
-        reconnect(unsubscribeOperation);
     }
 
     private synchronized void registerHeartbeatTimer(PubSubOperation pubSubOperation) {
@@ -232,6 +232,10 @@ public class SubscriptionManager {
         if (timer != null) {
             timer.cancel();
             timer = null;
+        }
+        if (heartbeatCall != null) {
+            heartbeatCall.silentCancel();
+            heartbeatCall = null;
         }
     }
 

--- a/src/main/java/com/pubnub/api/services/ExtendedPresenceService.java
+++ b/src/main/java/com/pubnub/api/services/ExtendedPresenceService.java
@@ -1,0 +1,41 @@
+package com.pubnub.api.services;
+
+import com.google.gson.JsonElement;
+import com.pubnub.api.models.server.Envelope;
+import com.pubnub.api.models.server.presence.WhereNowPayload;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.QueryMap;
+
+import java.util.Map;
+
+public interface ExtendedPresenceService {
+
+    @GET("v2/presence/sub-key/{subKey}/uuid/{uuid}")
+    Call<Envelope<WhereNowPayload>> whereNow(@Path("subKey") String subKey,
+                                             @Path("uuid") String uuid,
+                                             @QueryMap Map<String, String> options);
+
+    @GET("v2/presence/sub_key/{subKey}")
+    Call<Envelope<JsonElement>> globalHereNow(@Path("subKey") String subKey,
+                                              @QueryMap Map<String, String> options);
+
+    @GET("v2/presence/sub_key/{subKey}/channel/{channel}")
+    Call<Envelope<JsonElement>> hereNow(@Path("subKey") String subKey,
+                                        @Path("channel") String channel,
+                                        @QueryMap Map<String, String> options);
+
+    @GET("v2/presence/sub-key/{subKey}/channel/{channel}/uuid/{uuid}")
+    Call<Envelope<JsonElement>> getState(@Path("subKey") String subKey,
+                                         @Path("channel") String channel,
+                                         @Path("uuid") String uuid,
+                                         @QueryMap Map<String, String> options);
+
+    @GET("v2/presence/sub-key/{subKey}/channel/{channel}/uuid/{uuid}/data")
+    Call<Envelope<JsonElement>> setState(@Path("subKey") String subKey,
+                                         @Path("channel") String channel,
+                                         @Path("uuid") String uuid,
+                                         @QueryMap(encoded = true) Map<String, String> options);
+
+}

--- a/src/main/java/com/pubnub/api/services/PresenceService.java
+++ b/src/main/java/com/pubnub/api/services/PresenceService.java
@@ -1,8 +1,6 @@
 package com.pubnub.api.services;
 
-import com.google.gson.JsonElement;
 import com.pubnub.api.models.server.Envelope;
-import com.pubnub.api.models.server.presence.WhereNowPayload;
 import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Path;
@@ -21,31 +19,4 @@ public interface PresenceService {
     Call<Envelope> heartbeat(@Path("subKey") String subKey,
                              @Path("channel") String channel,
                              @QueryMap(encoded = true) Map<String, String> options);
-
-    @GET("v2/presence/sub-key/{subKey}/uuid/{uuid}")
-    Call<Envelope<WhereNowPayload>> whereNow(@Path("subKey") String subKey,
-                                             @Path("uuid") String uuid,
-                                             @QueryMap Map<String, String> options);
-
-    @GET("v2/presence/sub_key/{subKey}")
-    Call<Envelope<JsonElement>> globalHereNow(@Path("subKey") String subKey,
-                                              @QueryMap Map<String, String> options);
-
-    @GET("v2/presence/sub_key/{subKey}/channel/{channel}")
-    Call<Envelope<JsonElement>> hereNow(@Path("subKey") String subKey,
-                                        @Path("channel") String channel,
-                                        @QueryMap Map<String, String> options);
-
-    @GET("v2/presence/sub-key/{subKey}/channel/{channel}/uuid/{uuid}")
-    Call<Envelope<JsonElement>> getState(@Path("subKey") String subKey,
-                                         @Path("channel") String channel,
-                                         @Path("uuid") String uuid,
-                                         @QueryMap Map<String, String> options);
-
-    @GET("v2/presence/sub-key/{subKey}/channel/{channel}/uuid/{uuid}/data")
-    Call<Envelope<JsonElement>> setState(@Path("subKey") String subKey,
-                                         @Path("channel") String channel,
-                                         @Path("uuid") String uuid,
-                                         @QueryMap(encoded = true) Map<String, String> options);
-
 }


### PR DESCRIPTION
In some circumstances we do two contradicting calls in almost
the same time. One of them is a call to heartbeat endpoint and
the other is to leave endpoint. The reason why those call could
happen in almost the same time is because heartbeat calls are done
periodically on separate thread and leave calls are happening due to
user actions. This means that sooner or later this situation will happen
and pubnub presence system will generate join event and leave event (usually
in this order), but then another timeout event when presence timeout
expires.

To prevent it from happening I've decided to limit the number of concurrent
calls to only those two endpoints to just one. This is done on the okhttp
client level. Because those two calls can be ordered only two ways we can
provide an analysis of why this change might work.

Let's first concentrate on situation when heartbeat call is already happening
and unsubscribe method is being called:

* leave call will go to the internal queue of calls of okhttp client due to
limit of concurrent calls
* unsubscribe method internally will try to cancel the heartbeat call and schedule
timer with another heartbeat call (but with different set of channels)
* heartbeat finishes (either normally, or by being cancelled), this usually
do not generate any events, but it might generate join event
* http leave call can finally proceed, which generates leave event
* because the calls have been done sequentially there's no timeout event

In case when leave call is already ongoing and the schedule heartbeat timer
is trying to make heartbeat request:

* heartbeat request goes to client's internal queue to wait on leave to be finished
* in the meantime usubscribe method internally cancels the timer and cancels the heartbeat
request before it has time to start
* leave request ends, and leave event is being generated
* there's no timeout event, and the presence didn't have chance to be extended