### PR TITLE
Updated removeTrailingEqualSigns method from PubNubUtil.java 

### DIFF
--- a/src/main/java/com/pubnub/api/PubNubUtil.java
+++ b/src/main/java/com/pubnub/api/PubNubUtil.java
@@ -249,14 +249,13 @@ public class PubNubUtil {
 
     }
 
-    public static String removeTrailingEqualSigns(String signature) {
-        String cleanSignature = signature;
-
-        while ((cleanSignature.charAt(cleanSignature.length() - 1) == '=')) {
-            cleanSignature = cleanSignature.substring(0, cleanSignature.length() - 1);
-        }
-        return cleanSignature;
+public static String removeTrailingEqualSigns(String signature) {
+    StringBuilder cleanSignatureBuilder = new StringBuilder(signature);
+    while (cleanSignatureBuilder.charAt(cleanSignatureBuilder.length() - 1) == '=') {
+        cleanSignatureBuilder.setLength(cleanSignatureBuilder.length() - 1);
     }
+    return cleanSignatureBuilder.toString();
+}
 
     private static String requestBodyToString(final Request request) {
         if (request.body() == null) {


### PR DESCRIPTION
Updated the **removeTrailingEqualSigns** method with StringBuilder . 

Instead of repeatedly creating new strings in the while loop, you can use a StringBuilder to remove the trailing equal signs. A stringBuilder is an effiecient way to use strings without consuming memory due to the immutability of string. 

Read here more about StringBuilder  : https://stackoverflow.com/questions/41219283/advantage-of-string-over-stringbuilder-in-java