### PR TITLE
Move kt file to kotlin sourceset

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -119,8 +119,7 @@ changelog:
     version: v6.4.4
     changes:
       - type: bug
-        text: "Bring back compatibility with Android 6+ by removing the Jackson library dependency."
-  - date: 2023-11-28
+        text: "Bring back compatibility with Android 6+ by removing the Jackson library dependency."  - date: 2023-11-28
     version: v6.4.3
     changes:
       - type: feature

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -119,12 +119,7 @@ changelog:
     version: v6.4.4
     changes:
       - type: bug
-        text: "Bring back compatibility with Android 6+ by removing the Jackson library dependency."  - date: 2023-11-28
-    version: v6.4.3
-    changes:
-      - type: feature
-        text: "Add `error` field to `PNFileEventResult` and set it in case of decryption failure."
-  - date: 2023-11-23
+        text: "Bring back compatibility with Android 6+ by removing the Jackson library dependency."  - date: 2023-11-23
     version: v6.4.2
     changes:
       - type: bug

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -119,7 +119,18 @@ changelog:
     version: v6.4.4
     changes:
       - type: bug
-        text: "Bring back compatibility with Android 6+ by removing the Jackson library dependency."  - date: 2023-10-30
+        text: "Bring back compatibility with Android 6+ by removing the Jackson library dependency."  
+  - date: 2023-11-28
+    version: v6.4.3
+    changes:
+      - type: feature
+        text: "Add `error` field to `PNFileEventResult` and set it in case of decryption failure."
+  - date: 2023-11-23
+    version: v6.4.2
+    changes:
+      - type: bug
+        text: "Handle unencrypted message in subscribe and history when crypto configured (error flag is set on message result)."
+  - date: 2023-10-30
     version: v6.4.1
     changes:
       - type: bug

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -119,12 +119,7 @@ changelog:
     version: v6.4.4
     changes:
       - type: bug
-        text: "Bring back compatibility with Android 6+ by removing the Jackson library dependency."  - date: 2023-11-23
-    version: v6.4.2
-    changes:
-      - type: bug
-        text: "Handle unencrypted message in subscribe and history when crypto configured (error flag is set on message result)."
-  - date: 2023-10-30
+        text: "Bring back compatibility with Android 6+ by removing the Jackson library dependency."  - date: 2023-10-30
     version: v6.4.1
     changes:
       - type: bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ November 30 2023
 #### Fixed
 - Bring back compatibility with Android 6+ by removing the Jackson library dependency.
 
+
+
 ## v6.4.3
 November 28 2023
 

--- a/src/main/kotlin/com/pubnub/api/managers/token_manager/TokenParser.kt
+++ b/src/main/kotlin/com/pubnub/api/managers/token_manager/TokenParser.kt
@@ -10,10 +10,6 @@ import com.pubnub.api.models.consumer.access_manager.v3.PNToken
 import com.pubnub.api.vendor.Base64
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
-import kotlin.collections.Map
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.set
 import co.nstant.`in`.cbor.model.Map as CborMap
 
 internal class TokenParser {


### PR DESCRIPTION
fix: Bring back compatibility with Android 6+ by removing the Jackson library dependency
